### PR TITLE
[BE/feat]  EventPublisherAspect 개선

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/annotation/EventPublisherStatus.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/annotation/EventPublisherStatus.java
@@ -1,0 +1,10 @@
+package com.gaebaljip.exceed.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EventPublisherStatus {}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/EventPublisherAspect.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/EventPublisherAspect.java
@@ -8,17 +8,20 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Aspect
 @Component
 @ConditionalOnExpression("${ableDomainEvent:true}")
+@Slf4j
 public class EventPublisherAspect implements ApplicationEventPublisherAware {
 
     private ApplicationEventPublisher publisher;
     private ThreadLocal<Boolean> appliedLocal = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
-    @Around("@annotation(org.springframework.transaction.annotation.Transactional)")
+    @Around("@annotation(com.gaebaljip.exceed.common.annotation.EventPublisherStatus)")
     public Object handleEvent(ProceedingJoinPoint joinPoint) throws Throwable {
-
+        log.info("EventPublisherAspect.handleEvent joinPoint={}", joinPoint);
         boolean nested = appliedLocal.get();
 
         if (!nested) {

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/member/application/DeleteMemberService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/member/application/DeleteMemberService.java
@@ -3,6 +3,7 @@ package com.gaebaljip.exceed.member.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gaebaljip.exceed.common.annotation.EventPublisherStatus;
 import com.gaebaljip.exceed.common.event.DeleteMemberEvent;
 import com.gaebaljip.exceed.common.event.Events;
 import com.gaebaljip.exceed.member.adapter.out.persistence.MemberEntity;
@@ -18,6 +19,7 @@ public class DeleteMemberService implements DeleteMemberUseCase {
 
     @Override
     @Transactional
+    @EventPublisherStatus
     public void execute(Long memberId) {
         MemberEntity memberEntity = memberPort.query(memberId);
         Events.raise(DeleteMemberEvent.from(memberEntity));

--- a/BE/exceed/src/main/resources/db/testData.sql
+++ b/BE/exceed/src/main/resources/db/testData.sql
@@ -1,20 +1,10 @@
-USE gaebaljip;
-
-set foreign_key_checks = 0;
-truncate MEMBER_TB;
-truncate HISTORY_TB;
-truncate FOOD_TB;
-truncate MEAL_TB;
-truncate MEAL_FOOD_TB;
-truncate EAT_HABITS_TB;
-set foreign_key_checks = 1;
 
 INSERT INTO MEMBER_TB (MEMBER_PK, CREATED_DATE, UPDATED_DATE, MEMBER_ACTIVITY, MEMBER_AGE, MEMBER_ETC, MEMBER_GENDER,
                        MEMBER_HEIGHT, MEMBER_WEIGHT, MEMBER_EMAIL, MEMBER_PASSWORD, MEMBER_ROLE, MEMBER_CHECKED)
 VALUES (1, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 175.0, 61.0, 'abcd@gmail.com',
-        '$2a$10$pljAKl0Ad3LnjQyQei.Yz.0Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true), # 비밀번호 Abc@123
+        '$2a$10$pljAKl0Ad3LnjQyQei.Yz.0Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
        (2, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 175.0, 61.0, 'abcd2@gmail.com',
-        '$2a$10$pljAKl0Ad3LnjQyQei.Yz.0Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true); # 비밀번호 Abc@123
+        '$2a$10$pljAKl0Ad3LnjQyQei.Yz.0Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true);
 
 INSERT INTO HISTORY_TB(HISTORY_PK, CREATED_DATE, UPDATED_DATE, HISTORY_ACTIVITY,HISTORY_AGE,HISTORY_GENDER,HISTORY_HEIGHT, HISTORY_WEIGHT, MEMBER_FK)
 

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/auth/AuthControllerIntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/auth/AuthControllerIntegrationTest.java
@@ -16,7 +16,7 @@ class AuthControllerIntegrationTest extends IntegrationTest {
     @Test()
     @DisplayName("로그인 성공")
     void login() throws Exception {
-        LoginRequest loginRequest = new LoginRequest("abcd1111!@gmail.com", "abcd1234@");
+        LoginRequest loginRequest = new LoginRequest("abcd@gmail.com", "Abc@123");
 
         ResultActions resultActions =
                 mockMvc.perform(


### PR DESCRIPTION
## ⚠️ 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/259

## 📢 주요 변경사항

- @EventPublisherStatus 생성
- EventPublisherAspect의 조인포인트 트랜잭션 애노테이션에서 @EventPublisherStatus로 변경

## 리뷰어에게

EventPublisherStatus에서는 각 스레드마다 publisher를 세팅하고 있습니다.
기존에는 @Transactional이 적혀있는 모든 메서드에서 AOP가 작동되어 리소스 낭비가 있었습니다.
이에 마커 어노테이션을 도입해 해당 애노테이션이 있을 때만 작동하도록 수정하였습니다.