### PR TITLE
[BE/refactor] 회원가입 기능 개선

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/ExceedApplication.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/ExceedApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class ExceedApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(ExceedApplication.class, args);
     }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/Events.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/Events.java
@@ -14,6 +14,14 @@ public class Events {
         }
     }
 
+    public static void raise(InfraEvent event) {
+        if (event == null) return;
+
+        if (publisherLocal.get() != null) {
+            publisherLocal.get().publishEvent(event);
+        }
+    }
+
     public static void setPublisher(ApplicationEventPublisher publisher) {
         publisherLocal.set(publisher);
     }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/InfraEvent.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/InfraEvent.java
@@ -1,0 +1,14 @@
+package com.gaebaljip.exceed.common.event;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class InfraEvent {
+    private final LocalDateTime publishAt;
+
+    public InfraEvent() {
+        this.publishAt = LocalDateTime.now();
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/SendEmailEvent.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/SendEmailEvent.java
@@ -1,0 +1,15 @@
+package com.gaebaljip.exceed.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SendEmailEvent extends InfraEvent {
+
+    private String email;
+
+    public static SendEmailEvent from(String email) {
+        return new SendEmailEvent(email);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
@@ -1,0 +1,46 @@
+package com.gaebaljip.exceed.common.event.handler;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+
+import com.gaebaljip.exceed.common.Encryption;
+import com.gaebaljip.exceed.common.MailTemplate;
+import com.gaebaljip.exceed.common.event.SendEmailEvent;
+import com.gaebaljip.exceed.member.application.port.out.EmailPort;
+import com.gaebaljip.exceed.member.application.port.out.TimeOutPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SendEmailEventListener {
+
+    private final EmailPort emailPort;
+    private final Encryption encryption;
+    private final TimeOutPort timeOutPort;
+
+    @Value("${exceed.url}")
+    private String URL;
+
+    @EventListener(classes = SendEmailEvent.class)
+    public void handle(SendEmailEvent event) {
+        String uuid = UUID.randomUUID().toString();
+        timeOutPort.command(event.getEmail(), uuid);
+
+        String code = encryption.encrypt(uuid);
+        Context context = new Context();
+        context.setVariable(
+                MailTemplate.SIGN_UP_MAIL_CONTEXT, URL + MailTemplate.REPLY_TO_SIGN_UP_MAIL_URL);
+        context.setVariable(MailTemplate.SIGN_UP_CHECK_COOD, "&code=" + code);
+        context.setVariable(MailTemplate.SIGN_UP_EMAIL, "?email=" + event.getEmail());
+        emailPort.sendEmail(
+                event.getEmail(),
+                MailTemplate.SIGN_UP_TITLE,
+                MailTemplate.SIGN_UP_TEMPLATE,
+                context);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
@@ -3,8 +3,10 @@ package com.gaebaljip.exceed.common.event.handler;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.thymeleaf.context.Context;
 
 import com.gaebaljip.exceed.common.Encryption;
@@ -26,7 +28,8 @@ public class SendEmailEventListener {
     @Value("${exceed.url}")
     private String URL;
 
-    @EventListener(classes = SendEmailEvent.class)
+    @TransactionalEventListener(classes = SendEmailEvent.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(SendEmailEvent event) {
         String uuid = UUID.randomUUID().toString();
         timeOutPort.command(event.getEmail(), uuid);

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package com.gaebaljip.exceed.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import com.gaebaljip.exceed.member.exception.MailSendException;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(8);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(10);
+        executor.setKeepAliveSeconds(60);
+        executor.setRejectedExecutionHandler(
+                (r, exec) -> {
+                    throw MailSendException.EXECPTION;
+                });
+        executor.initialize();
+        return executor;
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
@@ -15,8 +15,8 @@ public class AsyncConfig implements AsyncConfigurer {
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(8);
-        executor.setMaxPoolSize(10);
+        executor.setCorePoolSize(16);
+        executor.setMaxPoolSize(25);
         executor.setQueueCapacity(10);
         executor.setKeepAliveSeconds(60);
         executor.setRejectedExecutionHandler(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/member/adapter/out/persistence/EmailAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/member/adapter/out/persistence/EmailAdapter.java
@@ -3,6 +3,7 @@ package com.gaebaljip.exceed.member.adapter.out.persistence;
 import java.util.concurrent.CompletableFuture;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
@@ -25,6 +26,7 @@ public class EmailAdapter implements EmailPort {
     private final SpringTemplateEngine htmlTemplateEngine;
 
     @Override
+    @Async
     public boolean sendEmail(String to, String title, String template, Context context) {
 
         String html = htmlTemplateEngine.process(template, context);

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/member/application/SendSignupEmailService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/member/application/SendSignupEmailService.java
@@ -1,19 +1,14 @@
 package com.gaebaljip.exceed.member.application;
 
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.context.Context;
 
-import com.gaebaljip.exceed.common.Encryption;
-import com.gaebaljip.exceed.common.MailTemplate;
+import com.gaebaljip.exceed.common.annotation.EventPublisherStatus;
+import com.gaebaljip.exceed.common.event.Events;
+import com.gaebaljip.exceed.common.event.SendEmailEvent;
 import com.gaebaljip.exceed.member.application.port.in.SendEmailCommand;
 import com.gaebaljip.exceed.member.application.port.in.SendEmailUsecase;
-import com.gaebaljip.exceed.member.application.port.out.EmailPort;
-import com.gaebaljip.exceed.member.application.port.out.TimeOutPort;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,31 +16,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Qualifier("SendSignupEmailService")
 public class SendSignupEmailService implements SendEmailUsecase {
-
-    private final EmailPort emailPort;
-    private final Encryption encryption;
-    private final TimeOutPort timeOutPort;
-
-    @Value("${exceed.url}")
-    private String URL;
-
     @Override
     @Transactional
+    @EventPublisherStatus
     public void execute(SendEmailCommand sendEmailCommand) {
-
-        String uuid = UUID.randomUUID().toString();
-        timeOutPort.command(sendEmailCommand.email(), uuid);
-
-        String code = encryption.encrypt(uuid);
-        Context context = new Context();
-        context.setVariable(
-                MailTemplate.SIGN_UP_MAIL_CONTEXT, URL + MailTemplate.REPLY_TO_SIGN_UP_MAIL_URL);
-        context.setVariable(MailTemplate.SIGN_UP_CHECK_COOD, "&code=" + code);
-        context.setVariable(MailTemplate.SIGN_UP_EMAIL, "?email=" + sendEmailCommand.email());
-        emailPort.sendEmail(
-                sendEmailCommand.email(),
-                MailTemplate.SIGN_UP_TITLE,
-                MailTemplate.SIGN_UP_TEMPLATE,
-                context);
+        Events.raise(SendEmailEvent.from(sendEmailCommand.email()));
     }
 }


### PR DESCRIPTION
## ⚠️ 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/261

## 📢 주요 변경사항

- 이메일 보낼 때 비동기 사용하여 처리 속도 개선
- 메일 보내는 기능을 Event를 사용하여 재사용성을 높임
- TaskExecutor 설정

<img width="500" alt="스크린샷 2024-05-25 오전 12 04 11" src="https://github.com/JNU-econovation/EATceed/assets/91835827/5a2f85cb-6c98-4e83-ada6-20ae31063b7c">

현재 배포 서버는 t3.small입니다. 따라서 2 코어이고 가용 가능한 스레드의 개수는 4개입니다.

아래의 적정 스레드 풀 공식을 참조하면, 4 x (1 + 3) = 16

<img width="563" alt="스크린샷 2024-05-25 오전 12 09 57" src="https://github.com/JNU-econovation/EATceed/assets/91835827/0bc5ae0c-3603-49e0-9912-072f760f1b0d">



###  적정 스레드 풀 공식
https://code-lab1.tistory.com/269

## 리뷰어에게

방학때는 부하 테스트를 시도해보면 좋을 것 같습니다.
추가로, 추후에 커넥션 풀 설정도 해줘야합니다.
