### PR TITLE
[BE/feat] : pr_review가 승인되고, be 브랜치에서만 workflow 실행하도록 수정

### DIFF
--- a/.github/workflows/testAndDeploy.yml
+++ b/.github/workflows/testAndDeploy.yml
@@ -11,12 +11,6 @@ defaults:
 
 jobs:
 
-  approved:
-    if: github.event.review.state == 'APPROVED'
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "This PR was approved"
-
   build:
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/testAndDeploy.yml
+++ b/.github/workflows/testAndDeploy.yml
@@ -1,9 +1,9 @@
 name: testAndDeploy
 
 on:
-  pull_request_target:
-    types:
-      - closed
+  pull_request_review:
+    types: [submitted]
+    branches: [ "be" ]
 
 defaults:
   run:
@@ -11,12 +11,11 @@ defaults:
 
 jobs:
 
-  if_merged:
-    if: github.event.pull_request.merged == true
+  approved:
+    if: github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo The PR was merged
+      - run: echo "This PR was approved"
 
   build:
     runs-on: ubuntu-22.04

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/IntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/IntegrationTest.java
@@ -19,8 +19,6 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.extern.slf4j.Slf4j;
-
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @ExtendWith(DatabaseClearExtension.class)


### PR DESCRIPTION
## ⚠️ 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/263

## 📢 주요 변경사항

fork한 레포에서 upstream 레포로 PR을 쏘면, Github Secrets이 동작하지 않습니다.

https://velog.io/@tilsong/Github-Secrets%EA%B0%80-%EB%8F%99%EC%9E%91%ED%95%98%EC%A7%80-%EC%95%8A%EB%8A%94%EB%8B%A4%EA%B5%AC%EC%9A%94-%EA%B7%B8%EA%B1%B4-%EC%95%84%EB%A7%88%EB%8F%84

따라서, 이제부터는 upstream 레포에서 feat/https://github.com/JNU-econovation/EATceed/issues/263 -> be로 PR하는 방식으로 변경하겠습니다.


https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges-1