### PR TITLE
[Be/fix] CI 시 Jacoco 테스트 커버리지 리포트 생성 안되는 오류 해결 

### DIFF
--- a/.github/workflows/testAndDeploy.yml
+++ b/.github/workflows/testAndDeploy.yml
@@ -5,7 +5,10 @@ on:
     types:
       - closed
 
-permissions: write-all
+permissions:
+  contents: read
+  pull-requests: write
+
 
 defaults:
   run:


### PR DESCRIPTION
## 🔑 주요 변경사항

```
permissions:
  contents: read
  pull-requests: write
 ```

권한 설정 추가
  