### PR TITLE
[BE/test] 웹 계층 단위테스트 보충

### DIFF
--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/GetMealControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/GetMealControllerTest.java
@@ -2,6 +2,7 @@ package com.gaebaljip.exceed.adapter.in.meal;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ import com.gaebaljip.exceed.common.dto.MaintainMealDTO;
 import com.gaebaljip.exceed.common.dto.TargetMealDTO;
 
 @WebMvcTest(GetMealController.class)
-class SpecificMealControllerTest extends ControllerTest {
+class GetMealControllerTest extends ControllerTest {
 
     @MockBean private GetMaintainMealUsecase getMaintainMealUsecase;
 
@@ -37,12 +38,12 @@ class SpecificMealControllerTest extends ControllerTest {
 
     @Test
     @WithMockUser
-    void getMealNutrition() throws Exception {
+    void when_getMeal_expected_success() throws Exception {
 
         // given
-        MaintainMealDTO maintainMealDTO = new MaintainMealDTO(100.0, 100.0, 100.0, 100.0);
-        CurrentMealDTO currentMealDTO = new CurrentMealDTO(100.0, 100.0, 100.0, 100.0);
-        TargetMealDTO targetMealDTO = new TargetMealDTO(100.0, 100.0, 100.0, 100.0);
+        MaintainMealDTO maintainMealDTO = new MaintainMealDTO(100.22, 100.22, 100.22, 100.22);
+        CurrentMealDTO currentMealDTO = new CurrentMealDTO(100.666, 100.666, 100.666, 100.666);
+        TargetMealDTO targetMealDTO = new TargetMealDTO(100.444, 100.444, 100.444, 100.444);
 
         // when
         Mockito.when(getMaintainMealUsecase.execute(any())).thenReturn(maintainMealDTO);
@@ -53,6 +54,10 @@ class SpecificMealControllerTest extends ControllerTest {
                 mockMvc.perform(get("/v1/meal").contentType(MediaType.APPLICATION_JSON));
 
         // then
-        resultActions.andExpect(status().isOk());
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.response.maintainMealDTO.calorie").value(100.22),
+                jsonPath("$.response.currentMealDTO.protein").value(100.67),
+                jsonPath("$.response.targetMealDTO.fat").value(100.44));
     }
 }

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAchieveControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAchieveControllerTest.java
@@ -3,6 +3,9 @@ package com.gaebaljip.exceed.adapter.in.nutritionist;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -19,11 +22,14 @@ class GetAchieveControllerTest extends ControllerTest {
     @MockBean private GetCalorieAnalysisUsecase getAchieveUsecase;
 
     @Test
+    @DisplayName("분석 조회 성공" + "요청 시 날짜 포맷 확인")
     @WithMockUser
-    void getAchieve() throws Exception {
+    void when_getAnalysis_expected_success() throws Exception {
+
+        LocalDate date = LocalDate.of(2023, 12, 8);
+
         ResultActions resultActions =
-                mockMvc.perform(
-                        get("/v1/achieve/2023-12-08").contentType(MediaType.APPLICATION_JSON));
+                mockMvc.perform(get("/v1/achieve/" + date).contentType(MediaType.APPLICATION_JSON));
 
         resultActions.andExpect(status().isOk());
     }


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/414

## 🔑 주요 변경사항

- 테스트 메서드 네이밍 when ~ expected 형식으로 수정
- 로그인 컨트롤러 단위 테스트에서 헤더와 쿠키에 대한 검증 추가
- 오늘 먹은 식사 컨트롤럴 단위 테스트에서 응답시 소수점 검증 추가
