### PR TITLE
[BE/test] 하루에 먹은 식사 영양소를 계산하는 DailyMeal 도메인 리팩토링 및 테스트

### DIFF
--- a/BE/exceed/build.gradle
+++ b/BE/exceed/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	testImplementation "org.testcontainers:testcontainers:1.19.8"
 	testImplementation "org.testcontainers:junit-jupiter:1.19.8"
 	testImplementation "org.testcontainers:localstack:1.19.8"
+	testImplementation "org.jeasy:easy-random-core:5.0.0"
 
 
 
@@ -216,8 +217,6 @@ jacocoTestReport {
 					fileTree(dir: it, excludes: [
 					        "**/ExceedApplication",
 							"**/*Config*",
-							"**/*Request*",
-							"**/*Response*",
 							"**/*Exception*",
 							"**/*Filter*",
 							"**/*Docs*",

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealConverter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealConverter.java
@@ -1,10 +1,9 @@
-package com.gaebaljip.exceed.application.port.out.meal;
+package com.gaebaljip.exceed.adapter.out.jpa.meal;
 
 import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.gaebaljip.exceed.adapter.out.jpa.meal.ConsumedFoodConverter;
 import com.gaebaljip.exceed.application.domain.meal.Meal;
 import com.gaebaljip.exceed.application.domain.meal.MealEntity;
 import com.gaebaljip.exceed.common.annotation.Timer;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
@@ -11,11 +11,10 @@ import com.gaebaljip.exceed.application.domain.meal.Meal;
 import com.gaebaljip.exceed.application.domain.meal.MealEntity;
 import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 import com.gaebaljip.exceed.application.port.out.meal.DailyMealPort;
-import com.gaebaljip.exceed.application.port.out.meal.MealConverter;
 import com.gaebaljip.exceed.application.port.out.meal.MealPort;
 import com.gaebaljip.exceed.common.annotation.Timer;
+import com.gaebaljip.exceed.common.dto.DailyMealDTO;
 import com.gaebaljip.exceed.common.dto.MonthlyMealDTO;
-import com.gaebaljip.exceed.common.dto.TodayMealDTO;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +24,6 @@ public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyM
 
     private final MealRepository mealRepository;
     private final MealConverter mealConverter;
-    private final int FIRST_DAY = 1;
 
     @Override
     public MealEntity command(MealEntity mealEntity) {
@@ -33,11 +31,11 @@ public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyM
     }
 
     @Override
-    public List<Meal> query(TodayMealDTO todayMealDTO) {
-        LocalDateTime today = todayMealDTO.date().toLocalDate().atStartOfDay();
+    public List<Meal> query(DailyMealDTO dailyMealDTO) {
+        LocalDateTime today = dailyMealDTO.date().toLocalDate().atStartOfDay();
         LocalDateTime tomorrow = today.plusDays(1);
         List<MealEntity> mealEntities =
-                mealRepository.findAllTodayMeal(today, tomorrow, todayMealDTO.memberId());
+                mealRepository.findAllTodayMeal(today, tomorrow, dailyMealDTO.memberId());
         return mealConverter.toMeals(mealEntities);
     }
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/ConsumedFood.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/ConsumedFood.java
@@ -4,9 +4,11 @@ import com.gaebaljip.exceed.application.domain.food.Food;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 public class ConsumedFood {
 
     private Food food;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/DailyMeal.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/DailyMeal.java
@@ -4,18 +4,16 @@ import static java.util.stream.Collectors.toSet;
 
 import java.util.List;
 
-import com.gaebaljip.exceed.common.exception.meal.InsufficientMealsException;
 import com.gaebaljip.exceed.common.exception.meal.NotSameDateException;
 
 import lombok.*;
 
 /**
- * 같은 날짜 즉, 하루에 먹은 식사를 나타내는 클래스 오늘 먹은 식사들을 분석하여 칼로리,단,탄,지를 계산한다.
+ * 하루에 먹은 식사들을 분석하여 칼로리,단,탄,지를 계산
  *
  * @author hwangdaesun
  * @version 1.0
  * @throws NotSameDateException : 식사들의 날짜가 다를 경우
- * @throws InsufficientMealsException : 식사를 한 번도 하지 않았을 경우
  */
 @Getter
 @ToString
@@ -24,8 +22,7 @@ public class DailyMeal {
     private final List<Meal> meals;
 
     public DailyMeal(List<Meal> meals) {
-        validateSize(meals);
-        validateSameMealDate(meals);
+        validateSameDateIfNotEmpty(meals);
         this.meals = meals;
     }
 
@@ -45,20 +42,21 @@ public class DailyMeal {
         return meals.stream().mapToDouble(Meal::getCurrentFat).sum();
     }
 
-    private void validateSize(List<Meal> meals) {
-        if (meals.isEmpty()) {
-            throw InsufficientMealsException.EXECPTION;
+    private void validateSameDateIfNotEmpty(List<Meal> meals) {
+        if (!meals.isEmpty() && !isSameDate(meals)) {
+            throw NotSameDateException.EXECPTION;
         }
     }
 
-    private void validateSameMealDate(List<Meal> meals) {
-        if (getDistinctSize(meals) != 1) throw NotSameDateException.EXECPTION;
-    }
-
-    private int getDistinctSize(List<Meal> meals) {
-        return meals.stream()
-                .map(meal -> meal.getMealDateTime().toLocalDate())
-                .collect(toSet())
-                .size();
+    private boolean isSameDate(List<Meal> meals) {
+        int size =
+                meals.stream()
+                        .map(meal -> meal.getMealDateTime().toLocalDate())
+                        .collect(toSet())
+                        .size();
+        if (size != 1) {
+            return false;
+        }
+        return true;
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/Unit.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/Unit.java
@@ -2,8 +2,10 @@ package com.gaebaljip.exceed.application.domain.meal;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 @Builder
 public class Unit {
     private double servingSize;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/meal/DailyMealPort.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/meal/DailyMealPort.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.gaebaljip.exceed.application.domain.meal.Meal;
-import com.gaebaljip.exceed.common.dto.TodayMealDTO;
+import com.gaebaljip.exceed.common.dto.DailyMealDTO;
 
 @Component
 public interface DailyMealPort {
-    List<Meal> query(TodayMealDTO todayMealDTO);
+    List<Meal> query(DailyMealDTO dailyMealDTO);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/meal/GetCurrentMealService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/meal/GetCurrentMealService.java
@@ -11,8 +11,8 @@ import com.gaebaljip.exceed.application.domain.meal.Meal;
 import com.gaebaljip.exceed.application.port.in.meal.GetCurrentMealQuery;
 import com.gaebaljip.exceed.application.port.out.meal.DailyMealPort;
 import com.gaebaljip.exceed.common.dto.CurrentMealDTO;
-import com.gaebaljip.exceed.common.dto.TodayMealDTO;
-import com.gaebaljip.exceed.common.exception.meal.InvalidMultipleException;
+import com.gaebaljip.exceed.common.dto.DailyMealDTO;
+import com.gaebaljip.exceed.common.exception.meal.NotSameDateException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,36 +26,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GetCurrentMealService implements GetCurrentMealQuery {
 
-    public static final double ZERO = 0.0;
     private final DailyMealPort dailyMealPort;
 
     /**
-     * DailyMeal 도메인이 오늘 먹은 식사들을 분석하여 칼로리,단,탄,지 정보를 반환한다. 만약 식사 정보가 존재하지 않을 경우는 칼로리,단,탄,지 모두 ZERO를
-     * 반환한다.
+     * DailyMeal 도메인이 오늘 먹은 식사들을 분석하여 칼로리,단,탄,지 정보를 반환
      *
-     * @param memberId : 누가 무엇을 언제 얼마나 먹었는 지에 대한 정보가 들어있다.
-     * @return mealId : 식사 엔티티의 PK
-     * @throws InvalidMultipleException : 0인분 이하거나 100인분 초과일 경우
+     * @param memberId : 누가 무엇을 언제 얼마나 먹었는 지에 대한 정보
+     * @return currentMealDTO : calorie, carbohydrate, protein, fat
+     * @throws NotSameDateException : 같은 날짜가 아닐 경우
      */
     @Override
     @Transactional(readOnly = true)
     public CurrentMealDTO execute(Long memberId) {
-        List<Meal> meals = dailyMealPort.query(new TodayMealDTO(memberId, LocalDateTime.now()));
-        if (meals.isEmpty()) {
-            return CurrentMealDTO.builder()
-                    .calorie(ZERO)
-                    .carbohydrate(ZERO)
-                    .fat(ZERO)
-                    .protein(ZERO)
-                    .build();
-        } else {
-            DailyMeal dailyMeal = new DailyMeal(meals);
-            return CurrentMealDTO.builder()
-                    .calorie(dailyMeal.calculateCurrentCalorie())
-                    .carbohydrate(dailyMeal.calculateCurrentCarbohydrate())
-                    .fat(dailyMeal.calculateCurrentFat())
-                    .protein(dailyMeal.calculateCurrentProtein())
-                    .build();
-        }
+        List<Meal> meals = dailyMealPort.query(new DailyMealDTO(memberId, LocalDateTime.now()));
+        DailyMeal dailyMeal = new DailyMeal(meals);
+        return CurrentMealDTO.of(
+                dailyMeal.calculateCurrentCalorie(),
+                dailyMeal.calculateCurrentCarbohydrate(),
+                dailyMeal.calculateCurrentProtein(),
+                dailyMeal.calculateCurrentFat());
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/AllAnalysisDTO.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/AllAnalysisDTO.java
@@ -1,6 +1,9 @@
 package com.gaebaljip.exceed.common.dto;
 
 import java.time.LocalDate;
+import java.util.List;
+
+import com.gaebaljip.exceed.application.domain.meal.Meal;
 
 public record AllAnalysisDTO(
         Boolean isVisited,
@@ -11,14 +14,14 @@ public record AllAnalysisDTO(
         boolean isCarbohydrateAchieved) {
 
     public static AllAnalysisDTO of(
-            Boolean isVisited,
+            List<Meal> meals,
             LocalDate date,
             boolean isCalorieAchieved,
             boolean isProteinAchieved,
             boolean isFatAchieved,
             boolean isCarbohydrateAchieved) {
         return new AllAnalysisDTO(
-                isVisited,
+                meals.isEmpty() ? false : true,
                 date,
                 isCalorieAchieved,
                 isProteinAchieved,

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/CurrentMealDTO.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/CurrentMealDTO.java
@@ -5,12 +5,20 @@ import com.gaebaljip.exceed.common.CustomDoubleSerializer;
 
 import lombok.Builder;
 
+@Builder
 public record CurrentMealDTO(
         @JsonSerialize(using = CustomDoubleSerializer.class) Double calorie,
         @JsonSerialize(using = CustomDoubleSerializer.class) Double carbohydrate,
         @JsonSerialize(using = CustomDoubleSerializer.class) Double protein,
         @JsonSerialize(using = CustomDoubleSerializer.class) Double fat) {
 
-    @Builder
-    public CurrentMealDTO {}
+    public static CurrentMealDTO of(
+            Double calorie, Double carbohydrate, Double protein, Double fat) {
+        return CurrentMealDTO.builder()
+                .calorie(calorie)
+                .carbohydrate(carbohydrate)
+                .protein(protein)
+                .fat(fat)
+                .build();
+    }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/DailyMealDTO.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/DailyMealDTO.java
@@ -8,10 +8,10 @@ import com.gaebaljip.exceed.common.ValidationMessage;
 
 import lombok.Builder;
 
-public record TodayMealDTO(
+public record DailyMealDTO(
         @NotNull(message = "memberId을 " + ValidationMessage.NOT_NULL) Long memberId,
         @NotNull(message = "날짜를 " + ValidationMessage.NOT_NULL) LocalDateTime date) {
 
     @Builder
-    public TodayMealDTO {}
+    public DailyMealDTO {}
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/SpecificMealDTO.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/dto/SpecificMealDTO.java
@@ -4,8 +4,14 @@ import java.util.List;
 
 import lombok.Builder;
 
+@Builder
 public record SpecificMealDTO(CurrentMealDTO currentMealDTO, List<MealRecordDTO> mealRecordDTOS) {
 
-    @Builder
-    public SpecificMealDTO {}
+    public static SpecificMealDTO of(
+            CurrentMealDTO currentMealDTO, List<MealRecordDTO> mealRecordDTOS) {
+        return SpecificMealDTO.builder()
+                .currentMealDTO(currentMealDTO)
+                .mealRecordDTOS(mealRecordDTOS)
+                .build();
+    }
 }

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/meal/DailyMealTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/meal/DailyMealTest.java
@@ -1,0 +1,35 @@
+package com.gaebaljip.exceed.application.domain.meal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.gaebaljip.exceed.common.exception.meal.NotSameDateException;
+import com.gaebaljip.exceed.common.factory.MealsFixtureFactory;
+
+class DailyMealTest {
+
+    @Test
+    void when_mealSize_0_expected_return0() {
+        List<Meal> meals = MealsFixtureFactory.create(LocalDate.now(), LocalDate.now(), 0);
+        DailyMeal dailyMeal = new DailyMeal(meals);
+        double calorie = dailyMeal.calculateCurrentCalorie();
+        assertEquals(calorie, 0.0);
+    }
+
+    @Test
+    void when_mealSize_over0_and_sameDate_expected_return_success() {
+        List<Meal> meals = MealsFixtureFactory.create(LocalDate.now(), LocalDate.now(), 3);
+        assertDoesNotThrow(() -> new DailyMeal(meals));
+    }
+
+    @Test
+    void when_mealSize_over0_and_NotSameDate_expected_return_exception() {
+        List<Meal> meals =
+                MealsFixtureFactory.create(LocalDate.now(), LocalDate.now().plusDays(2), 3);
+        assertThrows(NotSameDateException.class, () -> new DailyMeal(meals));
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/nutritionist/CalorieAnalyzerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/nutritionist/CalorieAnalyzerTest.java
@@ -1,0 +1,27 @@
+package com.gaebaljip.exceed.application.domain.nutritionist;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.gaebaljip.exceed.application.domain.meal.DailyMeal;
+import com.gaebaljip.exceed.application.domain.meal.Meal;
+import com.gaebaljip.exceed.application.domain.member.Member;
+import com.gaebaljip.exceed.common.factory.MealsFixtureFactory;
+import com.gaebaljip.exceed.common.factory.MemberFixtureFactory;
+
+class CalorieAnalyzerTest {
+    @Test
+    void when_meals_size_0_expected_false() {
+        List<Meal> meals = MealsFixtureFactory.create(LocalDate.now(), LocalDate.now(), 0);
+        Member member = MemberFixtureFactory.create(1);
+        CalorieAnalyzerFactory calorieAnalyzerFactory = CalorieAnalyzerFactory.getInstance();
+        CalorieAnalyzer calorieAnalyzer =
+                calorieAnalyzerFactory.createAnalyzer(new DailyMeal(meals), member);
+        boolean analyze = calorieAnalyzer.analyze();
+        assertEquals(analyze, false);
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/application/service/nutritionist/GetAllCalorieAnalysisServiceTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/application/service/nutritionist/GetAllCalorieAnalysisServiceTest.java
@@ -1,0 +1,81 @@
+package com.gaebaljip.exceed.application.service.nutritionist;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.gaebaljip.exceed.adapter.in.nutritionist.request.GetAllAnalysisRequest;
+import com.gaebaljip.exceed.application.domain.meal.Meal;
+import com.gaebaljip.exceed.application.domain.member.Member;
+import com.gaebaljip.exceed.application.port.out.meal.DailyMealPort;
+import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+import com.gaebaljip.exceed.common.dto.AllAnalysisDTO;
+import com.gaebaljip.exceed.common.dto.DailyMealDTO;
+import com.gaebaljip.exceed.common.factory.MealsFixtureFactory;
+import com.gaebaljip.exceed.common.factory.MemberFixtureFactory;
+
+@ExtendWith(MockitoExtension.class)
+class GetAllCalorieAnalysisServiceTest {
+
+    @Mock private DailyMealPort dailyMealPort;
+    @Mock private MemberPort memberPort;
+
+    @InjectMocks private GetAllCalorieAnalysisService getAllCalorieAnalysisService;
+
+    @Test
+    void when_meal_is_0_expected_isVisited_false_and_allAchieved_false() {
+
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Member member = MemberFixtureFactory.create(1);
+        GetAllAnalysisRequest request = getGetAllAnalysisRequest(now);
+        given(dailyMealPort.query(new DailyMealDTO(request.memberId(), request.dateTime())))
+                .willReturn(List.of());
+        given(memberPort.query(request.memberId(), request.dateTime())).willReturn(member);
+
+        // when
+        AllAnalysisDTO allAnalysisDTO = getAllCalorieAnalysisService.execute(request);
+
+        // then
+        assertAll(
+                () -> assertFalse(allAnalysisDTO.isVisited()),
+                () -> assertFalse(allAnalysisDTO.isCalorieAchieved()),
+                () -> assertFalse(allAnalysisDTO.isCarbohydrateAchieved()),
+                () -> assertFalse(allAnalysisDTO.isFatAchieved()),
+                () -> assertFalse(allAnalysisDTO.isProteinAchieved()),
+                () -> assertEquals(request.dateTime().toLocalDate(), now.toLocalDate()));
+    }
+
+    @Test
+    void when_meal_is_3_expected_isVisited_false_and_allAchieved_false() {
+
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Member member = MemberFixtureFactory.create(1);
+        GetAllAnalysisRequest request = getGetAllAnalysisRequest(now);
+        List<Meal> meals = MealsFixtureFactory.create(now.toLocalDate(), now.toLocalDate(), 3);
+        given(dailyMealPort.query(new DailyMealDTO(request.memberId(), request.dateTime())))
+                .willReturn(meals);
+        given(memberPort.query(request.memberId(), request.dateTime())).willReturn(member);
+
+        // when
+        AllAnalysisDTO allAnalysisDTO = getAllCalorieAnalysisService.execute(request);
+
+        // then
+        assertAll(
+                () -> assertTrue(allAnalysisDTO.isVisited()),
+                () -> assertEquals(request.dateTime().toLocalDate(), now.toLocalDate()));
+    }
+
+    private GetAllAnalysisRequest getGetAllAnalysisRequest(LocalDateTime localDateTime) {
+        return new GetAllAnalysisRequest(1L, localDateTime);
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MealsFixtureFactory.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MealsFixtureFactory.java
@@ -1,0 +1,31 @@
+package com.gaebaljip.exceed.common.factory;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.api.Randomizer;
+
+import com.gaebaljip.exceed.application.domain.meal.Meal;
+import com.gaebaljip.exceed.application.domain.meal.Unit;
+
+public class MealsFixtureFactory {
+    public static List<Meal> create(LocalDate startDate, LocalDate endDate, int mealSize) {
+        EasyRandomParameters easyRandomParameters =
+                new EasyRandomParameters()
+                        .scanClasspathForConcreteTypes(true)
+                        .dateRange(startDate, endDate)
+                        .randomize(Unit.class, new UnitRandomizer());
+        EasyRandom easyRandom = new EasyRandom(easyRandomParameters);
+        return easyRandom.objects(Meal.class, mealSize).toList();
+    }
+
+    private static class UnitRandomizer implements Randomizer<Unit> {
+        @Override
+        public Unit getRandomValue() {
+            Unit unit = Unit.builder().g(null).multiple(1.0).build();
+            return unit;
+        }
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MemberFixtureFactory.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MemberFixtureFactory.java
@@ -1,0 +1,28 @@
+package com.gaebaljip.exceed.common.factory;
+
+import static org.jeasy.random.FieldPredicates.named;
+
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+
+import com.gaebaljip.exceed.application.domain.member.Member;
+
+public class MemberFixtureFactory {
+    public static Member create(int gender) {
+        EasyRandomParameters parameters =
+                new EasyRandomParameters()
+                        .randomize(
+                                Double.class,
+                                () -> Math.random() * 100 + 1) // double 타입 랜덤 값 생성 (1~100 사이의 값)
+                        .randomize(
+                                Integer.class,
+                                () ->
+                                        (int)
+                                                (Math.random() * 100
+                                                        + 1)) // int 타입 랜덤 값 생성 (1~100 사이의 값)
+                        .excludeField(named("gender")); // gender 필드는 제외
+
+        EasyRandom easyRandom = new EasyRandom(parameters);
+        return easyRandom.nextObject(Member.class).toBuilder().gender(gender).build();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/423

## 🔑 주요 변경사항

- DailyMeal 도메인이 특정 날짜에 식사를 아예 하지 않았을 경우 포함하도록(객체 응집성이 높아지도록) 리팩토링

```java

if (meals.isEmpty()) {
            return CurrentMealDTO.builder()
                    .calorie(ZERO)
                    .carbohydrate(ZERO)
                    .fat(ZERO)
                    .protein(ZERO)
                    .build();
} 

```

이를 통해, 기존 GetCurrentMealService, GetSpecificMealService, GetAllCalorieAnlysisService에 있던 meals.isEmpty() 관련 로직을 DailyMeal 내부에서 처리 가능

- EasyRandom을 이용해 DailyMeal 도메인 테스트 및 CalorieAnalyzer 도메인 테스트
- Object Mother 패턴 이용해서 객체 FixtureFactory 생성
- GetAllCalorieAnlysisService 단위 테스트 수행
