### PR TITLE
[Be/fix] 특정 날짜의 식사 정보 조회하는 API 오류 수정

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/GetMealController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/GetMealController.java
@@ -15,6 +15,7 @@ import com.gaebaljip.exceed.adapter.in.meal.response.GetMealResponse;
 import com.gaebaljip.exceed.adapter.in.nutritionist.request.GetAllAnalysisRequest;
 import com.gaebaljip.exceed.application.port.in.meal.GetCurrentMealQuery;
 import com.gaebaljip.exceed.application.port.in.meal.GetSpecificMealQuery;
+import com.gaebaljip.exceed.application.port.in.meal.ValidateBeforeSignUpUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetMaintainMealUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetTargetMealUsecase;
 import com.gaebaljip.exceed.application.service.nutritionist.GetAllCalorieAnalysisService;
@@ -46,6 +47,7 @@ public class GetMealController {
     private final GetCurrentMealQuery getCurrentMealQuery;
     private final GetSpecificMealQuery getSpecificMealQuery;
     private final GetAllCalorieAnalysisService getAllCalorieAnalysisService;
+    private final ValidateBeforeSignUpUsecase validateDateBeforeSignUpUsecase;
 
     /** 오늘 먹은 식사 정보(단,탄,지 및 칼로리) 조회 */
     @Operation(summary = "오늘 먹은 식사 정보 조회", description = "오늘 먹은 식사 정보(단,탄,지 및 칼로리)를 조회한다.")
@@ -68,6 +70,7 @@ public class GetMealController {
             @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
             @Parameter(hidden = true) @AuthenticationMemberId Long memberId) {
         LocalDateTime localDateTime = date.atStartOfDay();
+        validateDateBeforeSignUpUsecase.execute(memberId, localDateTime);
         MaintainMealDTO maintainMealDTO = getMaintainMealUsecase.execute(memberId, localDateTime);
         TargetMealDTO targetMealDTO = getTargetMealUsecase.execute(memberId, localDateTime);
         SpecificMealDTO specificMealDTO = getSpecificMealQuery.execute(memberId, localDateTime);

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/HistoryPersistenceAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/HistoryPersistenceAdapter.java
@@ -21,8 +21,8 @@ public class HistoryPersistenceAdapter implements HistoryPort {
     }
 
     @Override
-    public HistoryEntity findByMemberIdAndDate(Long memberId, LocalDateTime date) {
-        return historyRepository.findByMemberIdAndDate(memberId, date);
+    public HistoryEntity findMostRecentFutureMember(Long memberId, LocalDateTime date) {
+        return historyRepository.findMostRecentFutureMember(memberId, date);
     }
 
     @Override

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/MemberPersistenceAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/MemberPersistenceAdapter.java
@@ -72,8 +72,8 @@ public class MemberPersistenceAdapter implements MemberPort {
     }
 
     @Override
-    public Optional<MemberEntity> findByIdAndDate(Long memberId, LocalDateTime date) {
-        return memberRepository.findByIdAndDate(memberId, date);
+    public Optional<MemberEntity> findMemberBeforeDate(Long memberId, LocalDateTime date) {
+        return memberRepository.findMemberBeforeDate(memberId, date);
     }
 
     @Override

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepository.java
@@ -8,5 +8,5 @@ import com.gaebaljip.exceed.application.domain.member.HistoryEntity;
 
 @Repository
 public interface CustomHistoryRepository {
-    HistoryEntity findByMemberIdAndDate(Long memberId, LocalDateTime date);
+    HistoryEntity findMostRecentFutureMember(Long memberId, LocalDateTime date);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImpl.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImpl.java
@@ -22,15 +22,20 @@ public class CustomHistoryRepositoryImpl implements CustomHistoryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public HistoryEntity findByMemberIdAndDate(Long memberId, LocalDateTime date) {
+    public HistoryEntity findMostRecentFutureMember(Long memberId, LocalDateTime date) {
         return queryFactory
                 .selectFrom(historyEntity)
-                .where(historyEntity.id.eq(memberId).and(checkDate(historyEntity, date)))
-                .orderBy(historyEntity.id.desc())
+                .where(
+                        historyEntity
+                                .memberEntity
+                                .id
+                                .eq(memberId)
+                                .and(checkFutureDate(historyEntity, date)))
+                .orderBy(historyEntity.createdDate.asc())
                 .fetchFirst();
     }
 
-    private BooleanExpression checkDate(QHistoryEntity historyEntity, LocalDateTime date) {
-        return historyEntity.createdDate.before(date);
+    private BooleanExpression checkFutureDate(QHistoryEntity historyEntity, LocalDateTime date) {
+        return historyEntity.createdDate.after(date);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImpl.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImpl.java
@@ -31,7 +31,7 @@ public class CustomHistoryRepositoryImpl implements CustomHistoryRepository {
                                 .id
                                 .eq(memberId)
                                 .and(checkFutureDate(historyEntity, date)))
-                .orderBy(historyEntity.createdDate.asc())
+                .orderBy(historyEntity.id.asc())
                 .fetchFirst();
     }
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomMemberRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomMemberRepository.java
@@ -9,5 +9,5 @@ import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 
 @Repository
 public interface CustomMemberRepository {
-    Optional<MemberEntity> findByIdAndDate(Long memberId, LocalDateTime date);
+    Optional<MemberEntity> findMemberBeforeDate(Long memberId, LocalDateTime date);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomMemberRepositoryImpl.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomMemberRepositoryImpl.java
@@ -21,7 +21,7 @@ public class CustomMemberRepositoryImpl implements CustomMemberRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<MemberEntity> findByIdAndDate(Long memberId, LocalDateTime date) {
+    public Optional<MemberEntity> findMemberBeforeDate(Long memberId, LocalDateTime date) {
         MemberEntity result =
                 queryFactory
                         .selectFrom(memberEntity)
@@ -31,6 +31,6 @@ public class CustomMemberRepositoryImpl implements CustomMemberRepository {
     }
 
     private BooleanExpression checkDate(QMemberEntity memberEntity, LocalDateTime date) {
-        return memberEntity.createdDate.eq(date);
+        return memberEntity.updatedDate.before(date);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/member/MemberEntity.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/member/MemberEntity.java
@@ -1,5 +1,7 @@
 package com.gaebaljip.exceed.application.domain.member;
 
+import java.time.LocalDateTime;
+
 import javax.persistence.*;
 
 import org.hibernate.annotations.ColumnDefault;
@@ -97,5 +99,9 @@ public class MemberEntity extends BaseEntity {
                 && this.getActivity() != null
                 && this.getGender() != null
                 && this.getTargetWeight() != null;
+    }
+
+    public boolean checkIfBeforeSignUp(LocalDateTime checkDateTime) {
+        return checkDateTime.isBefore(this.getCreatedDate());
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/meal/ValidateBeforeSignUpUsecase.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/meal/ValidateBeforeSignUpUsecase.java
@@ -1,0 +1,10 @@
+package com.gaebaljip.exceed.application.port.in.meal;
+
+import java.time.LocalDateTime;
+
+import com.gaebaljip.exceed.common.annotation.UseCase;
+
+@UseCase
+public interface ValidateBeforeSignUpUsecase {
+    void execute(Long memberId, LocalDateTime dateTime);
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/member/HistoryPort.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/member/HistoryPort.java
@@ -11,7 +11,7 @@ import com.gaebaljip.exceed.common.annotation.Port;
 public interface HistoryPort {
     HistoryEntity command(HistoryEntity historyEntity);
 
-    HistoryEntity findByMemberIdAndDate(Long memberId, LocalDateTime date);
+    HistoryEntity findMostRecentFutureMember(Long memberId, LocalDateTime date);
 
     List<HistoryEntity> findByMemberEntity(MemberEntity memberEntity);
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/member/MemberPort.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/member/MemberPort.java
@@ -23,7 +23,7 @@ public interface MemberPort {
 
     MemberEntity findCheckedMemberByEmail(String email);
 
-    Optional<MemberEntity> findByIdAndDate(Long memberId, LocalDateTime date);
+    Optional<MemberEntity> findMemberBeforeDate(Long memberId, LocalDateTime date);
 
     Boolean existsByEmail(String email);
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/meal/ValidateBeforeSignupService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/meal/ValidateBeforeSignupService.java
@@ -1,0 +1,27 @@
+package com.gaebaljip.exceed.application.service.meal;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import com.gaebaljip.exceed.adapter.out.jpa.member.MemberPersistenceAdapter;
+import com.gaebaljip.exceed.application.domain.member.MemberEntity;
+import com.gaebaljip.exceed.application.port.in.meal.ValidateBeforeSignUpUsecase;
+import com.gaebaljip.exceed.common.exception.meal.InValidDateFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ValidateBeforeSignupService implements ValidateBeforeSignUpUsecase {
+
+    private final MemberPersistenceAdapter memberPersistenceAdapter;
+
+    @Override
+    public void execute(Long memberId, LocalDateTime dateTime) {
+        MemberEntity memberEntity = memberPersistenceAdapter.query(memberId);
+        if (memberEntity.checkIfBeforeSignUp(dateTime)) {
+            throw InValidDateFoundException.EXECPTION;
+        }
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/GetMaintainMealService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/GetMaintainMealService.java
@@ -47,12 +47,13 @@ public class GetMaintainMealService implements GetMaintainMealUsecase {
     @Override
     @Transactional(readOnly = true)
     public MaintainMealDTO execute(Long memberId, LocalDateTime date) {
-        Optional<MemberEntity> memberEntity = memberPort.findByIdAndDate(memberId, date);
+        Optional<MemberEntity> memberEntity = memberPort.findMemberBeforeDate(memberId, date);
         if (memberEntity.isPresent()) {
             Member member = memberConverter.toModel(memberEntity.get());
             return toMaintainMeal(member);
         } else {
-            HistoryEntity lastestHistoryEntity = historyPort.findByMemberIdAndDate(memberId, date);
+            HistoryEntity lastestHistoryEntity =
+                    historyPort.findMostRecentFutureMember(memberId, date);
             Member member = memberConverter.toModel(lastestHistoryEntity);
             return toMaintainMeal(member);
         }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/GetTargetMealService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/GetTargetMealService.java
@@ -46,12 +46,13 @@ public class GetTargetMealService implements GetTargetMealUsecase {
 
     @Override
     public TargetMealDTO execute(Long memberId, LocalDateTime date) {
-        Optional<MemberEntity> memberEntity = memberPort.findByIdAndDate(memberId, date);
+        Optional<MemberEntity> memberEntity = memberPort.findMemberBeforeDate(memberId, date);
         if (memberEntity.isPresent()) {
             Member member = memberConverter.toModel(memberEntity.get());
             return toTargetMeal(member);
         } else {
-            HistoryEntity lastestHistoryEntity = historyPort.findByMemberIdAndDate(memberId, date);
+            HistoryEntity lastestHistoryEntity =
+                    historyPort.findMostRecentFutureMember(memberId, date);
             Member member = memberConverter.toModel(lastestHistoryEntity);
             return toTargetMeal(member);
         }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/meal/GetMealExceptionDocs.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/meal/GetMealExceptionDocs.java
@@ -1,7 +1,6 @@
 package com.gaebaljip.exceed.common.docs.meal;
 
 import com.gaebaljip.exceed.common.exception.EatCeedException;
-import com.gaebaljip.exceed.common.exception.meal.InsufficientMealsException;
 import com.gaebaljip.exceed.common.exception.meal.InvalidMultipleException;
 import com.gaebaljip.exceed.common.exception.meal.NotSameDateException;
 import com.gaebaljip.exceed.common.exception.member.InvalidGenderException;
@@ -12,9 +11,6 @@ import com.gaebaljip.exceed.common.swagger.SwaggerExampleExceptions;
 
 @ExceptionDoc
 public class GetMealExceptionDocs implements SwaggerExampleExceptions {
-    @ExplainError("Daily Meal에 최소 1끼도 제공 되지 않았을 때 ")
-    public EatCeedException Daily_Meal에_최소_1끼도_제공_되지_않았습니다 = InsufficientMealsException.EXECPTION;
-
     @ExplainError("0인분 이하거나 100인분 초과일 경우 ")
     public EatCeedException _0인분_이하거나_100인분_초과일_경우 = InvalidMultipleException.EXECPTION;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/meal/GetMealFoodExceptionDocs.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/meal/GetMealFoodExceptionDocs.java
@@ -1,7 +1,7 @@
 package com.gaebaljip.exceed.common.docs.meal;
 
 import com.gaebaljip.exceed.common.exception.EatCeedException;
-import com.gaebaljip.exceed.common.exception.meal.InsufficientMealsException;
+import com.gaebaljip.exceed.common.exception.meal.InValidDateFoundException;
 import com.gaebaljip.exceed.common.exception.meal.NotSameDateException;
 import com.gaebaljip.exceed.common.exception.member.InvalidGenderException;
 import com.gaebaljip.exceed.common.exception.member.MemberNotFoundException;
@@ -11,9 +11,6 @@ import com.gaebaljip.exceed.common.swagger.SwaggerExampleExceptions;
 
 @ExceptionDoc
 public class GetMealFoodExceptionDocs implements SwaggerExampleExceptions {
-    @ExplainError("Daily Meal에 최소 1끼도 제공 되지 않았을 때 ")
-    public EatCeedException Daily_Meal에_최소_1끼도_제공_되지_않았습니다 = InsufficientMealsException.EXECPTION;
-
     @ExplainError("식사들의 날짜가 다를 경우")
     public EatCeedException 식사들의_날짜가_다를_경우 = NotSameDateException.EXECPTION;
 
@@ -22,4 +19,7 @@ public class GetMealFoodExceptionDocs implements SwaggerExampleExceptions {
 
     @ExplainError("회원이 존재하지 않을 때")
     public EatCeedException 회원이_없을_때 = MemberNotFoundException.EXECPTION;
+
+    @ExplainError("켈린더 상세 조회시 회원가입 전의 기록을 보려고 할 때")
+    public EatCeedException 회원가입_전의_기록_열람시 = InValidDateFoundException.EXECPTION;
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/InValidDateFoundException.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/InValidDateFoundException.java
@@ -1,0 +1,14 @@
+package com.gaebaljip.exceed.common.exception.meal;
+
+import com.gaebaljip.exceed.common.exception.EatCeedException;
+
+import lombok.Getter;
+
+@Getter
+public class InValidDateFoundException extends EatCeedException {
+    public static EatCeedException EXECPTION = new InValidDateFoundException();
+
+    public InValidDateFoundException() {
+        super(MealError.INVALID_DATE_FOUND);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/MealError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/MealError.java
@@ -21,7 +21,8 @@ public enum MealError implements BaseError {
             400,
             "6002",
             "'multiple'은 null이 아니고 'g'는 null이어야 하거나, 'multiple'은 null이고 'g'는 null이 아니어야 합니다."),
-    INVALID_G(400, "6002", "g은 1 이상이어야합니다.");
+    INVALID_G(400, "6002", "g은 1 이상이어야합니다."),
+    INVALID_DATE_FOUND(400, "6321", "회원가입 이전의 기록은 없습니다.");
 
     private final Integer status;
     private final String code;

--- a/BE/exceed/src/main/resources/db/testData.sql
+++ b/BE/exceed/src/main/resources/db/testData.sql
@@ -1,31 +1,33 @@
 
 INSERT INTO MEMBER_TB (MEMBER_PK, CREATED_DATE, UPDATED_DATE, MEMBER_ACTIVITY, MEMBER_AGE, MEMBER_ETC, MEMBER_GENDER,
                        MEMBER_HEIGHT, MEMBER_WEIGHT, MEMBER_TARGET_WEIGHT, MEMBER_EMAIL, MEMBER_PASSWORD, MEMBER_ROLE, MEMBER_CHECKED)
-VALUES (1, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 175.0, 70.0, 68.0, 'abcd123!@gmail.com',
+VALUES (1, '2023-12-01 08:00:00', '2023-12-07 09:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 175.0, 70.0, 78.0, 'abcd123!@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.0Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (2, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 178.0, 72.0, 69.0, 'abcd234@@gmail.com',
+       (2, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 178.0, 72.0, 79.0, 'abcd234@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.2Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (3, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 165.0, 60.0, 58.0, 'abcd345@@gmail.com',
+       (3, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 165.0, 60.0, 78.0, 'abcd345@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.3Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (4, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 180.0, 75.0, 72.0, 'abcd456@@gmail.com',
+       (4, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 180.0, 75.0, 82.0, 'abcd456@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.4Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (5, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 170.0, 68.0, 65.0, 'abcd567@@gmail.com',
+       (5, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 170.0, 68.0, 75.0, 'abcd567@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.5Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (6, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 177.0, 71.0, 67.0, 'abcd678@@gmail.com',
+       (6, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 177.0, 71.0, 77.0, 'abcd678@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.6Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (7, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 169.0, 69.0, 64.0, 'abcd789@@gmail.com',
+       (7, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 169.0, 69.0, 74.0, 'abcd789@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.7Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (8, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 181.0, 74.0, 70.0, 'abcd890@@gmail.com',
+       (8, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 181.0, 74.0, 90.0, 'abcd890@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.8Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (9, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 168.0, 65.0, 62.0, 'abcd901@@gmail.com',
+       (9, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 168.0, 65.0, 72.0, 'abcd901@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.9Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true),
-       (10, '2023-12-01 08:00:00', '2023-12-01 08:00:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 172.0, 66.0, 63.0, 'abcd012@@gmail.com',
+       (10, '2023-12-01 08:00:00', '2023-12-01 08:10:00', 'NOT_ACTIVE', 30, '비고 없음', 1, 172.0, 66.0, 73.0, 'abcd012@@gmail.com',
         '$2a$10$pljAKl0Ad3LnjQyQei.Yz.0Cfcn3Zv/xeBMDwUHDaUrfG8Wm57c56', 'MEMBER', true);
 
 
 INSERT INTO HISTORY_TB(HISTORY_PK, CREATED_DATE, UPDATED_DATE, HISTORY_ACTIVITY,HISTORY_AGE,HISTORY_GENDER,HISTORY_HEIGHT, HISTORY_WEIGHT, MEMBER_FK)
 
-VALUES(1, '2023-11-20 08:00:00', '2023-11-20 08:00:00', 'NOT_ACTIVE', 30, 1, 175.0, 65.8, 1);
+VALUES(1, '2023-12-03 11:00:00', '2023-12-03 11:00:00', 'NOT_ACTIVE', 30, 1, 175.0, 71.0, 1),
+      (2, '2023-12-05 09:00:00', '2023-12-05 09:00:00', 'NOT_ACTIVE', 30, 1, 175.0, 72.0, 1),
+      (3, '2023-12-07 09:00:00', '2023-12-07 09:00:00', 'NOT_ACTIVE', 30, 1, 175.0, 73.0, 1);
 
 
 

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/GetMealControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/GetMealControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.gaebaljip.exceed.application.port.in.meal.GetCurrentMealQuery;
 import com.gaebaljip.exceed.application.port.in.meal.GetSpecificMealQuery;
+import com.gaebaljip.exceed.application.port.in.meal.ValidateBeforeSignUpUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetMaintainMealUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetTargetMealUsecase;
 import com.gaebaljip.exceed.application.service.nutritionist.GetAllCalorieAnalysisService;
@@ -35,6 +36,8 @@ class GetMealControllerTest extends ControllerTest {
     @MockBean private GetSpecificMealQuery getSpecificMealQuery;
 
     @MockBean private GetAllCalorieAnalysisService getAllCalorieAnalysisService;
+
+    @MockBean private ValidateBeforeSignUpUsecase validateDateBeforeSignUpUsecase;
 
     @Test
     @WithMockUser

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImplTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImplTest.java
@@ -19,7 +19,7 @@ class CustomHistoryRepositoryImplTest extends DatabaseTest {
     @DisplayName(
             "회원 1L : 2023-12-03 11:00:00, 2023-12-05 09:00:00, 그리고 2023-12-07 09:00:00에 회원 수정"
                     + "2023-12-04의 회원 정보를 열람할 경우 2023-12-05 09:00:00 에 저장된 회원 정보를 조회해야한다.")
-    void findMostRecentFutureMember() {
+    void when_findMostRecentFutureMemberWeight_expected_72() {
         LocalDateTime dateTime = LocalDateTime.of(2023, 12, 04, 12, 00);
         HistoryEntity historyEntity =
                 customHistoryRepository.findMostRecentFutureMember(1L, dateTime);

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImplTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomHistoryRepositoryImplTest.java
@@ -1,0 +1,28 @@
+package com.gaebaljip.exceed.adapter.out.jpa.member.custom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.gaebaljip.exceed.application.domain.member.HistoryEntity;
+import com.gaebaljip.exceed.common.DatabaseTest;
+
+class CustomHistoryRepositoryImplTest extends DatabaseTest {
+
+    @Autowired private CustomHistoryRepositoryImpl customHistoryRepository;
+
+    @Test
+    @DisplayName(
+            "회원 1L : 2023-12-03 11:00:00, 2023-12-05 09:00:00, 그리고 2023-12-07 09:00:00에 회원 수정"
+                    + "2023-12-04의 회원 정보를 열람할 경우 2023-12-05 09:00:00 에 저장된 회원 정보를 조회해야한다.")
+    void findMostRecentFutureMember() {
+        LocalDateTime dateTime = LocalDateTime.of(2023, 12, 04, 12, 00);
+        HistoryEntity historyEntity =
+                customHistoryRepository.findMostRecentFutureMember(1L, dateTime);
+        assertEquals(historyEntity.getWeight(), 72.0);
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomMemberRepositoryImplTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/member/custom/CustomMemberRepositoryImplTest.java
@@ -1,0 +1,44 @@
+package com.gaebaljip.exceed.adapter.out.jpa.member.custom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.gaebaljip.exceed.application.domain.member.MemberEntity;
+import com.gaebaljip.exceed.common.DatabaseTest;
+
+class CustomMemberRepositoryImplTest extends DatabaseTest {
+
+    @Autowired private CustomMemberRepositoryImpl customMemberRepository;
+
+    @Test
+    @DisplayName(
+            "회원 1L : 2023년 11월 20일에 회원가입"
+                    + " 2023년 12월 01일에 회원 수정하신 경우"
+                    + " 2024년 07월 22일에 조회하면 2023년 12월 1일의 회원이 조회되야한다. ")
+    void when_findByIdAndDate_expected_memberEntity_1L() {
+        LocalDateTime dateTime = LocalDateTime.of(2024, 07, 22, 12, 00);
+        Optional<MemberEntity> memberEntity =
+                customMemberRepository.findMemberBeforeDate(1L, dateTime);
+        assertAll(
+                () -> assertEquals(70.0, memberEntity.get().getWeight()),
+                () -> assertEquals(175.0, memberEntity.get().getHeight()));
+    }
+
+    @Test
+    @DisplayName(
+            "회원 1L : 2023년 11월 20일에 회원가입"
+                    + " 2023년 12월 01일에 회원 수정하신 경우"
+                    + " 2023년 11월 24일 기준으로 조회하면, 회원이 조회되지 않는다. ")
+    void when_findByIdAndDate_expected_memberEntity_null() {
+        LocalDateTime dateTime = LocalDateTime.of(2023, 11, 24, 12, 00);
+        Optional<MemberEntity> memberEntity =
+                customMemberRepository.findMemberBeforeDate(1L, dateTime);
+        assertAll(() -> assertTrue(memberEntity.isEmpty()));
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/DatabaseTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/DatabaseTest.java
@@ -1,0 +1,14 @@
+package com.gaebaljip.exceed.common;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.gaebaljip.exceed.config.QueryDslConfig;
+
+@Sql("classpath:db/testData.sql")
+@Import(QueryDslConfig.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class DatabaseTest extends ContainerTest {}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MemberFixtureFactory.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MemberFixtureFactory.java
@@ -11,15 +11,8 @@ public class MemberFixtureFactory {
     public static Member create(int gender) {
         EasyRandomParameters parameters =
                 new EasyRandomParameters()
-                        .randomize(
-                                Double.class,
-                                () -> Math.random() * 100 + 1) // double 타입 랜덤 값 생성 (1~100 사이의 값)
-                        .randomize(
-                                Integer.class,
-                                () ->
-                                        (int)
-                                                (Math.random() * 100
-                                                        + 1)) // int 타입 랜덤 값 생성 (1~100 사이의 값)
+                        .randomize(Double.class, () -> Math.random() * 50 + 40)
+                        .randomize(Integer.class, () -> (int) (Math.random() * 10 + 10))
                         .excludeField(named("gender")); // gender 필드는 제외
 
         EasyRandom easyRandom = new EasyRandom(parameters);

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/GetWeightIntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/GetWeightIntegrationTest.java
@@ -35,6 +35,6 @@ public class GetWeightIntegrationTest extends IntegrationTest {
         resultActions.andExpect(status().isOk());
         assertAll(
                 () -> assertEquals(member.getWeight(), 70.0),
-                () -> assertEquals(member.getTargetWeight(), 68.0));
+                () -> assertEquals(member.getTargetWeight(), 78.0));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/425

## 🔑 주요 변경사항

- CustomMemberRepositoryImpl 클래스의 findByMemberIdAndDate메서드 수정

켈린더 상세 조회시 해당 회원의 상태는 특정 날짜에 따라 달라져야 한다. 따라서, 특정 날짜 기준으로 MemberEntity의 updatedAt 필드가 그 전에 있을 경우 MemberEntity에 저장된 회원 정보를 사용한다.

- CustomHistoryRepositoryImpl의 findByMemberIdAndDate 메서드 수정

그리고, 특정 날짜 기준으로 MemberEntity updated 필드가 그 이후에 있다면 과거 변경 이력이 있다는 뜻으로 HistoryEntity를 확인하다.
이때, HistoryEntity의 경우 특정 날짜를 기준으로 미래중 가장 가까운 기록을 사용한다.

- CustomMemberRepositoryImpl 클래스, CustomHistoryRepositoryImpl 클래스 쿼리 테스트 수행
- 회원가입한 날짜보다 전의 켈린더 조회하는 경우 Validate하는 ValidateBeforeSignUpUsecase 개발 


- 특정 날짜의 식사 정보 조회하는 API 통합 테스트 보충  (식사 기록이 없을 경우, 회원가입 되기 전 날짜를 조회한 경우)
