### PR TITLE
[Be/Test] 테스트 환경 개선

### DIFF
--- a/BE/exceed/src/main/resources/application-test.yml
+++ b/BE/exceed/src/main/resources/application-test.yml
@@ -54,3 +54,6 @@ logging:
         type:
           descriptor:
             sql: info
+      springframework:
+        test.context.cache: debug
+

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/auth/AuthControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/auth/AuthControllerTest.java
@@ -5,21 +5,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.gaebaljip.exceed.adapter.in.auth.request.LoginRequest;
-import com.gaebaljip.exceed.application.service.auth.AuthService;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.dto.LoginResponseDTO;
 
-@WebMvcTest(AuthController.class)
 public class AuthControllerTest extends ControllerTest {
-    @MockBean private AuthService authService;
 
     @Test()
     @DisplayName("로그인 실패 - 비밀번호 형식 안 맞을 때")

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/food/CreateFoodControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/food/CreateFoodControllerTest.java
@@ -5,21 +5,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.gaebaljip.exceed.adapter.in.food.request.CreateFoodRequest;
-import com.gaebaljip.exceed.application.service.food.CreateFoodService;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.WithMockUser;
 
-@WebMvcTest(CreateFoodController.class)
 public class CreateFoodControllerTest extends ControllerTest {
-    @MockBean private CreateFoodService createFoodService;
 
     @Test
     @DisplayName("음식 추가 : 실패 - 이름이 없는 경우")

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/EatMealControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/EatMealControllerTest.java
@@ -9,24 +9,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.gaebaljip.exceed.adapter.in.meal.request.EatMealRequest;
-import com.gaebaljip.exceed.application.port.in.meal.EatMealUsecase;
-import com.gaebaljip.exceed.application.port.in.meal.UploadImageUsecase;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.WithMockUser;
 import com.gaebaljip.exceed.common.dto.EatMealFoodDTO;
 
-@WebMvcTest(EatMealController.class)
 class EatMealControllerTest extends ControllerTest {
-
-    @MockBean private EatMealUsecase eatMealUsecase;
-    @MockBean private UploadImageUsecase uploadImageUsecase;
 
     @Test
     @WithMockUser

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/GetMealControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/meal/GetMealControllerTest.java
@@ -7,37 +7,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.gaebaljip.exceed.application.port.in.meal.GetCurrentMealQuery;
-import com.gaebaljip.exceed.application.port.in.meal.GetSpecificMealQuery;
-import com.gaebaljip.exceed.application.port.in.meal.ValidateBeforeSignUpUsecase;
-import com.gaebaljip.exceed.application.port.in.member.GetMaintainMealUsecase;
-import com.gaebaljip.exceed.application.port.in.member.GetTargetMealUsecase;
-import com.gaebaljip.exceed.application.service.nutritionist.GetAllCalorieAnalysisService;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.WithMockUser;
 import com.gaebaljip.exceed.common.dto.CurrentMealDTO;
 import com.gaebaljip.exceed.common.dto.MaintainMealDTO;
 import com.gaebaljip.exceed.common.dto.TargetMealDTO;
 
-@WebMvcTest(GetMealController.class)
 class GetMealControllerTest extends ControllerTest {
-
-    @MockBean private GetMaintainMealUsecase getMaintainMealUsecase;
-
-    @MockBean private GetTargetMealUsecase getTargetMealUsecase;
-
-    @MockBean private GetCurrentMealQuery getCurrentMealQuery;
-
-    @MockBean private GetSpecificMealQuery getSpecificMealQuery;
-
-    @MockBean private GetAllCalorieAnalysisService getAllCalorieAnalysisService;
-
-    @MockBean private ValidateBeforeSignUpUsecase validateDateBeforeSignUpUsecase;
 
     @Test
     @WithMockUser

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/OnBoardingControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/OnBoardingControllerTest.java
@@ -5,22 +5,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.gaebaljip.exceed.adapter.in.member.request.OnBoardingMemberRequest;
-import com.gaebaljip.exceed.application.service.member.OnBoardingMemberService;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.WithMockUser;
 
-@WebMvcTest(OnBoardingController.class)
 class OnBoardingControllerTest extends ControllerTest {
-
-    @MockBean private OnBoardingMemberService onBoardingMemberService;
 
     @Test
     @DisplayName("온보딩 성공")

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberControllerTest.java
@@ -6,20 +6,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.gaebaljip.exceed.adapter.in.member.request.UpdateMemberRequest;
-import com.gaebaljip.exceed.application.port.in.member.UpdateMemberUsecase;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.WithMockUser;
 
-@WebMvcTest(UpdateMemberController.class)
 public class UpdateMemberControllerTest extends ControllerTest {
-    @MockBean private UpdateMemberUsecase updateMemberUsecase;
 
     @Test
     @DisplayName("회원 수정 성공")

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateWeightControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateWeightControllerTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.event.ApplicationEvents;
@@ -19,17 +17,14 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.gaebaljip.exceed.adapter.in.member.request.UpdateWeightRequest;
-import com.gaebaljip.exceed.application.port.in.member.UpdateWeightUsecase;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.WithMockUser;
 import com.gaebaljip.exceed.common.event.Events;
 import com.gaebaljip.exceed.common.event.UpdateWeightEvent;
 
 @RecordApplicationEvents
-@WebMvcTest(UpdateWeightController.class)
 public class UpdateWeightControllerTest extends ControllerTest {
 
-    @MockBean UpdateWeightUsecase updateWeightUsecase;
     @Autowired ApplicationEvents events;
     @Autowired ApplicationEventPublisher applicationEventPublisher;
 

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/notify/EmitterControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/notify/EmitterControllerTest.java
@@ -1,4 +1,4 @@
-package com.gaebaljip.exceed.infrastructure.adapter.in;
+package com.gaebaljip.exceed.adapter.in.notify;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -6,20 +6,13 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import com.gaebaljip.exceed.adapter.in.notify.EmitterController;
-import com.gaebaljip.exceed.application.port.in.notify.ConnectEmitterUseCase;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.WithMockUser;
 
-@WebMvcTest(EmitterController.class)
 public class EmitterControllerTest extends ControllerTest {
-
-    @MockBean private ConnectEmitterUseCase connectEmitterUseCase;
 
     @Test
     @WithMockUser(memberId = 1L)

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAchieveControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAchieveControllerTest.java
@@ -7,19 +7,13 @@ import java.time.LocalDate;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.gaebaljip.exceed.application.port.in.nutritionist.GetCalorieAnalysisUsecase;
 import com.gaebaljip.exceed.common.ControllerTest;
 import com.gaebaljip.exceed.common.WithMockUser;
 
-@WebMvcTest(GetAnalysisController.class)
 class GetAchieveControllerTest extends ControllerTest {
-
-    @MockBean private GetCalorieAnalysisUsecase getAchieveUsecase;
 
     @Test
     @DisplayName("분석 조회 성공" + "요청 시 날짜 포맷 확인")

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/ControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/ControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
@@ -15,15 +17,68 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaebaljip.exceed.adapter.in.auth.AuthController;
+import com.gaebaljip.exceed.adapter.in.food.CreateFoodController;
+import com.gaebaljip.exceed.adapter.in.meal.EatMealController;
+import com.gaebaljip.exceed.adapter.in.meal.GetMealController;
+import com.gaebaljip.exceed.adapter.in.member.OnBoardingController;
+import com.gaebaljip.exceed.adapter.in.member.UpdateMemberController;
+import com.gaebaljip.exceed.adapter.in.member.UpdateWeightController;
+import com.gaebaljip.exceed.adapter.in.notify.EmitterController;
+import com.gaebaljip.exceed.adapter.in.nutritionist.GetAnalysisController;
+import com.gaebaljip.exceed.application.port.in.meal.*;
+import com.gaebaljip.exceed.application.port.in.member.GetMaintainMealUsecase;
+import com.gaebaljip.exceed.application.port.in.member.GetTargetMealUsecase;
+import com.gaebaljip.exceed.application.port.in.member.UpdateMemberUsecase;
+import com.gaebaljip.exceed.application.port.in.member.UpdateWeightUsecase;
+import com.gaebaljip.exceed.application.port.in.notify.ConnectEmitterUseCase;
+import com.gaebaljip.exceed.application.port.in.nutritionist.GetCalorieAnalysisUsecase;
+import com.gaebaljip.exceed.application.service.auth.AuthService;
+import com.gaebaljip.exceed.application.service.food.CreateFoodService;
+import com.gaebaljip.exceed.application.service.member.OnBoardingMemberService;
+import com.gaebaljip.exceed.application.service.nutritionist.GetAllCalorieAnalysisService;
 
 @ActiveProfiles("test")
 @ExtendWith(RestDocumentationExtension.class)
+@WebMvcTest({
+    AuthController.class,
+    CreateFoodController.class,
+    EatMealController.class,
+    GetMealController.class,
+    OnBoardingController.class,
+    UpdateMemberController.class,
+    UpdateWeightController.class,
+    GetAnalysisController.class,
+    EmitterController.class
+})
 public abstract class ControllerTest {
+
     @Autowired protected MockMvc mockMvc;
 
     @Autowired protected ObjectMapper om;
 
     @Autowired private WebApplicationContext webApplicationContext;
+
+    @MockBean protected AuthService authService;
+    @MockBean protected CreateFoodService createFoodService;
+    @MockBean protected EatMealUsecase eatMealUsecase;
+    @MockBean protected UploadImageUsecase uploadImageUsecase;
+    @MockBean protected GetMaintainMealUsecase getMaintainMealUsecase;
+
+    @MockBean protected GetTargetMealUsecase getTargetMealUsecase;
+
+    @MockBean protected GetCurrentMealQuery getCurrentMealQuery;
+
+    @MockBean protected GetSpecificMealQuery getSpecificMealQuery;
+
+    @MockBean protected GetAllCalorieAnalysisService getAllCalorieAnalysisService;
+
+    @MockBean protected ValidateBeforeSignUpUsecase validateDateBeforeSignUpUsecase;
+    @MockBean protected OnBoardingMemberService onBoardingMemberService;
+    @MockBean protected UpdateMemberUsecase updateMemberUsecase;
+    @MockBean protected UpdateWeightUsecase updateWeightUsecase;
+    @MockBean protected GetCalorieAnalysisUsecase getAchieveUsecase;
+    @MockBean protected ConnectEmitterUseCase connectEmitterUseCase;
 
     @BeforeEach
     public void setup(RestDocumentationContextProvider restDocumentation) {

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/ControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/ControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
@@ -39,7 +40,7 @@ import com.gaebaljip.exceed.application.service.member.OnBoardingMemberService;
 import com.gaebaljip.exceed.application.service.nutritionist.GetAllCalorieAnalysisService;
 
 @ActiveProfiles("test")
-@ExtendWith(RestDocumentationExtension.class)
+@ExtendWith({RestDocumentationExtension.class})
 @WebMvcTest({
     AuthController.class,
     CreateFoodController.class,
@@ -51,34 +52,34 @@ import com.gaebaljip.exceed.application.service.nutritionist.GetAllCalorieAnalys
     GetAnalysisController.class,
     EmitterController.class
 })
+@MockBeans({
+    @MockBean(AuthService.class),
+    @MockBean(CreateFoodService.class),
+    @MockBean(EatMealUsecase.class),
+    @MockBean(UploadImageUsecase.class),
+    @MockBean(GetMaintainMealUsecase.class),
+    @MockBean(GetTargetMealUsecase.class),
+    @MockBean(GetCurrentMealQuery.class),
+    @MockBean(GetSpecificMealQuery.class),
+    @MockBean(GetAllCalorieAnalysisService.class),
+    @MockBean(ValidateBeforeSignUpUsecase.class),
+    @MockBean(OnBoardingMemberService.class),
+    @MockBean(UpdateMemberUsecase.class),
+    @MockBean(UpdateWeightUsecase.class),
+    @MockBean(GetCalorieAnalysisUsecase.class),
+    @MockBean(ConnectEmitterUseCase.class)
+})
 public abstract class ControllerTest {
 
     @Autowired protected MockMvc mockMvc;
-
     @Autowired protected ObjectMapper om;
-
     @Autowired private WebApplicationContext webApplicationContext;
-
-    @MockBean protected AuthService authService;
-    @MockBean protected CreateFoodService createFoodService;
-    @MockBean protected EatMealUsecase eatMealUsecase;
-    @MockBean protected UploadImageUsecase uploadImageUsecase;
-    @MockBean protected GetMaintainMealUsecase getMaintainMealUsecase;
-
-    @MockBean protected GetTargetMealUsecase getTargetMealUsecase;
-
-    @MockBean protected GetCurrentMealQuery getCurrentMealQuery;
-
-    @MockBean protected GetSpecificMealQuery getSpecificMealQuery;
-
-    @MockBean protected GetAllCalorieAnalysisService getAllCalorieAnalysisService;
-
-    @MockBean protected ValidateBeforeSignUpUsecase validateDateBeforeSignUpUsecase;
-    @MockBean protected OnBoardingMemberService onBoardingMemberService;
-    @MockBean protected UpdateMemberUsecase updateMemberUsecase;
-    @MockBean protected UpdateWeightUsecase updateWeightUsecase;
-    @MockBean protected GetCalorieAnalysisUsecase getAchieveUsecase;
-    @MockBean protected ConnectEmitterUseCase connectEmitterUseCase;
+    @Autowired protected AuthService authService;
+    @Autowired protected UploadImageUsecase uploadImageUsecase;
+    @Autowired protected GetMaintainMealUsecase getMaintainMealUsecase;
+    @Autowired protected GetTargetMealUsecase getTargetMealUsecase;
+    @Autowired protected GetCurrentMealQuery getCurrentMealQuery;
+    @Autowired protected ConnectEmitterUseCase connectEmitterUseCase;
 
     @BeforeEach
     public void setup(RestDocumentationContextProvider restDocumentation) {

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/IntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/IntegrationTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureMockMvc
 @ExtendWith(RestDocumentationExtension.class)
 @ExtendWith(DatabaseClearExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, args = "food_data.csv")
 @Sql("classpath:db/testData.sql")
 public abstract class IntegrationTest extends ContainerTest {
 

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/food/GetFoodIntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/food/GetFoodIntegrationTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.ResultActions;
@@ -26,7 +25,6 @@ import com.gaebaljip.exceed.common.exception.food.FoodError;
 
 import lombok.extern.slf4j.Slf4j;
 
-@SpringBootTest(args = "food_data.csv")
 @Slf4j
 public class GetFoodIntegrationTest extends IntegrationTest {
     String PRE_FIX = "prefix";

--- a/BE/exceed/src/test/resources/logback-test.xml
+++ b/BE/exceed/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <logger name="org.springframework.test.context.cache" level="DEBUG"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/429

## 🔑 주요 변경사항

Spring TestContext Framework는 Spring ApplicationContext 인스턴스 및 WebApplicationContext 인스턴스의 일관된 로딩과 해당 컨텍스트의 캐싱을 제공합니다.

하지만, 현재 개발집의 테스트는 컨텍스트 캐싱을 잘 활용하지 못 하고 있습니다.

따라서, 이번 PR에서는 테스트 컨텍스트 캐싱을 잘 활용할 수 있도록 테스트 환경을 개선하였습니다.

## 현재 테스트 컨텍스트를 재활용하지 못 한 횟수

<img width="608" alt="스크린샷 2024-07-23 오후 5 40 49" src="https://github.com/user-attachments/assets/d744f3d9-985b-4fc2-a309-980110ce4050">


## 개선

테스트를 통합 테스트, 웹 계층 테스트, 영속성 계층 테스트로 분류하여 각 성격의 테스트마다 같은 ApplicationContext를 사용하도록 코드를 개선하였습니다.

## 결과

<img width="594" alt="스크린샷 2024-07-23 오후 5 41 47" src="https://github.com/user-attachments/assets/f6d93cfc-6d25-4ca0-959f-fa35f542a786">    


<br />
     

Application Context를 재활용하지 못한 횟수가 13회에서 4회로 줄었습니다.

수행 시간 자체는 크게 줄지는 않았지만, 테스트 수가 더 많아지면 많아질 수록 유의미한 결과가 있을 것이라 생각됩니다.


