### PR TITLE
[BE/PERF] 분석 API 쿼리 개선

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealFoodConverter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealFoodConverter.java
@@ -1,0 +1,39 @@
+package com.gaebaljip.exceed.adapter.out.jpa.meal;
+
+import static java.util.stream.Collectors.groupingBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.gaebaljip.exceed.application.domain.meal.Meal;
+import com.gaebaljip.exceed.application.domain.meal.MealEntity;
+import com.gaebaljip.exceed.application.domain.meal.MealFoodEntity;
+import com.gaebaljip.exceed.common.annotation.Timer;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MealFoodConverter {
+
+    private final ConsumedFoodConverter converter;
+
+    @Timer
+    public List<Meal> toMeals(List<MealFoodEntity> mealFoodEntities) {
+        Map<MealEntity, List<MealFoodEntity>> mealEntityListMap =
+                mealFoodEntities.stream().collect(groupingBy(MealFoodEntity::getMealEntity));
+        return mealEntityListMap.keySet().stream()
+                .map(mealEntity -> toMeal(mealEntityListMap.get(mealEntity), mealEntity.getId()))
+                .toList();
+    }
+
+    private Meal toMeal(List<MealFoodEntity> mealFoodEntities, Long mealId) {
+        return Meal.builder()
+                .id(mealId)
+                .mealDateTime(mealFoodEntities.get(0).getCreatedDate())
+                .consumedFoods(converter.toConsumedFoods(mealFoodEntities))
+                .build();
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealFoodRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealFoodRepository.java
@@ -19,4 +19,7 @@ public interface MealFoodRepository extends JpaRepository<MealFoodEntity, Long> 
 
     @Query("select mf from MealFoodEntity mf where mf.mealEntity.memberEntity = :memberEntity")
     List<MealFoodEntity> findByMemberEntity(MemberEntity memberEntity);
+
+    @Query("select mft from MealFoodEntity mft join fetch mft.foodEntity where mft.id in :ids")
+    List<MealFoodEntity> findMFTByIdInQuery(List<Long> ids);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
@@ -14,6 +14,7 @@ import com.gaebaljip.exceed.adapter.out.jpa.nutritionist.MonthlyMealPort;
 import com.gaebaljip.exceed.application.domain.meal.DailyMeal;
 import com.gaebaljip.exceed.application.domain.meal.Meal;
 import com.gaebaljip.exceed.application.domain.meal.MealEntity;
+import com.gaebaljip.exceed.application.domain.meal.MealFoodEntity;
 import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 import com.gaebaljip.exceed.application.domain.nutritionist.MonthlyMeal;
 import com.gaebaljip.exceed.application.port.out.meal.DailyMealPort;
@@ -30,6 +31,8 @@ public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyM
 
     private final MealRepository mealRepository;
     private final MealConverter mealConverter;
+    private final MealFoodConverter mealFoodConverter;
+    private final MealFoodRepository mealFoodRepository;
 
     @Override
     public MealEntity command(MealEntity mealEntity) {
@@ -52,10 +55,12 @@ public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyM
         LocalDateTime startOfMonth = date.with(TemporalAdjusters.firstDayOfMonth());
         LocalDateTime endOfMonth = date.with(TemporalAdjusters.firstDayOfNextMonth());
 
-        List<MealEntity> mealEntities =
+        List<Long> mealIds =
                 mealRepository.findMealsByMemberAndMonth(
                         startOfMonth, endOfMonth, monthlyMealDTO.memberId());
-        List<Meal> meals = mealConverter.toMeals(mealEntities);
+        List<MealFoodEntity> mealFoodEntities = mealFoodRepository.findMFTByIdInQuery(mealIds);
+
+        List<Meal> meals = mealFoodConverter.toMeals(mealFoodEntities);
         Map<LocalDate, DailyMeal> monthlyMeal =
                 meals.stream()
                         .collect(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
@@ -20,8 +20,8 @@ public interface MealRepository extends JpaRepository<MealEntity, Long> {
 
     @Timer
     @Query(
-            "select m from MealEntity m join fetch m.mealFoodEntity mf join fetch mf.foodEntity where m.createdDate >= :startOfMonth and m.createdDate < :endOfMonth and m.memberEntity.id = :memberId")
-    List<MealEntity> findMealsByMemberAndMonth(
+            "select m.id from MealEntity m where m.memberEntity.id = :memberId and m.createdDate >= :startOfMonth and m.createdDate < :endOfMonth")
+    List<Long> findMealsByMemberAndMonth(
             LocalDateTime startOfMonth, LocalDateTime endOfMonth, Long memberId);
 
     void deleteByMemberEntity(MemberEntity memberEntity);

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapterTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapterTest.java
@@ -1,0 +1,65 @@
+package com.gaebaljip.exceed.adapter.out.jpa.meal;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.gaebaljip.exceed.application.domain.meal.Meal;
+import com.gaebaljip.exceed.application.domain.nutritionist.MonthlyMeal;
+import com.gaebaljip.exceed.common.DatabaseTest;
+import com.gaebaljip.exceed.common.dto.DailyMealDTO;
+import com.gaebaljip.exceed.common.dto.MonthlyMealDTO;
+
+class MealPersistenceAdapterTest extends DatabaseTest {
+
+    @Autowired private MealPersistenceAdapter mealPersistenceAdapter;
+
+    @Test
+    void when_queryForDaily_expected_success() {
+        LocalDateTime dateTime = LocalDateTime.of(2024, 6, 10, 11, 11);
+        List<Meal> meals = mealPersistenceAdapter.query(new DailyMealDTO(1L, dateTime));
+        assertAll(
+                () -> assertEquals(2, meals.size()),
+                () -> assertEquals(1, meals.get(0).getConsumedFoods().size()),
+                () -> assertEquals(1, meals.get(1).getConsumedFoods().size()));
+    }
+
+    @Test
+    void when_queryForMonth_expected_success() {
+        LocalDateTime dateTime = LocalDateTime.of(2024, 6, 20, 23, 22);
+        LocalDateTime plusDateTime = dateTime.plusDays(1);
+        MonthlyMealDTO monthlyMealDTO = new MonthlyMealDTO(1L, dateTime);
+        MonthlyMeal monthlyMeal = mealPersistenceAdapter.query(monthlyMealDTO);
+
+        assertAll(
+                () -> assertEquals(30, monthlyMeal.getMonthlyMeal().size()),
+                () ->
+                        assertEquals(
+                                3,
+                                monthlyMeal.getMonthlyMeal().values().stream()
+                                        .filter(dailyMeal -> dailyMeal.isEmptyMeals())
+                                        .toList()
+                                        .size()),
+                () ->
+                        assertEquals(
+                                2,
+                                monthlyMeal
+                                        .getMonthlyMeal()
+                                        .get(dateTime.toLocalDate())
+                                        .getMeals()
+                                        .size()),
+                () ->
+                        assertEquals(
+                                2,
+                                monthlyMeal
+                                        .getMonthlyMeal()
+                                        .get(plusDateTime.toLocalDate())
+                                        .getMeals()
+                                        .size()));
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/DatabaseTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/DatabaseTest.java
@@ -5,12 +5,26 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.gaebaljip.exceed.adapter.out.jpa.food.FoodConverter;
+import com.gaebaljip.exceed.adapter.out.jpa.meal.ConsumedFoodConverter;
+import com.gaebaljip.exceed.adapter.out.jpa.meal.MealConverter;
+import com.gaebaljip.exceed.adapter.out.jpa.meal.MealFoodConverter;
+import com.gaebaljip.exceed.adapter.out.jpa.meal.MealPersistenceAdapter;
 import com.gaebaljip.exceed.adapter.out.jpa.member.HistoryPersistenceAdapter;
 import com.gaebaljip.exceed.application.service.member.MemberConverter;
 import com.gaebaljip.exceed.config.QueryDslConfig;
 
 @Sql("classpath:db/testData.sql")
-@Import({QueryDslConfig.class, MemberConverter.class, HistoryPersistenceAdapter.class})
+@Import({
+    QueryDslConfig.class,
+    MemberConverter.class,
+    HistoryPersistenceAdapter.class,
+    MealPersistenceAdapter.class,
+    MealConverter.class,
+    FoodConverter.class,
+    ConsumedFoodConverter.class,
+    MealFoodConverter.class
+})
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class DatabaseTest extends ContainerTest {}


### PR DESCRIPTION
## 📌 관련 이슈



## 🔑 주요 변경사항

앱을 출시하기 전 “앱 출시 6개월 후 활발하게 활동하는 회원이 100명 정도라 가정”하고 성능 테스트를 진행

<img width="796" alt="스크린샷 2024-08-06 오후 9 39 54" src="https://github.com/user-attachments/assets/87700728-af31-4de1-8ee1-594c5506b6af">

회원 100명이 6개월동안 아침,점심,저녁,간식을 모두 먹는다고 가정하면 100 * 6 * 30 * 4 = 72,000 개이다. 
유저가 회원가입 한 시기를 고려하여, 프로시저를 사용해 각 테이블에 데이터를 넣은 결과 MEAL_COUNT는 67,400개이다.
그리고, 한 끼당 음식은 4가지 음식을 먹는걸로 가정하였습니다.


## 기존 쿼리

``` sql
select *
from MEAL_TB meal
	INNER JOIN MEAL_FOOD_TB MFT on meal.MEAL_PK = MFT.MEAL_FK
	INNER JOIN FOOD_TB food on MFT.FOOD_FK = food.FOOD_PK
where meal.CREATED_DATE >= '2024-06-01 00:00:00'
 and meal.CREATED_DATE < '2024-06-30 23:59:59'
 and meal.MEMBER_FK = 4;
```

실행 계획 

<img width="1046" alt="스크린샷 2024-08-06 오후 9 40 44" src="https://github.com/user-attachments/assets/0c04b064-afc4-470d-805d-da5194ce317a">

프로파일링

<img width="1229" alt="스크린샷 2024-08-06 오후 9 52 52" src="https://github.com/user-attachments/assets/844fc645-0d09-4ee5-adfa-c1227fa53282">

**평균 0.764s 경과**

실행 계획 결과 MEAL_FOOD_TB에서 Full Scan하고 이후에 각  MEAL_FOOD_TB의 FK들을 이용해 각 테이블(FOOD_TB와 MEAL_TB)를 스캔


##  기존 인덱스를 사용하는 방향으로 쿼리 개선

```sql
SELECT meal.MEAL_PK
    FROM MEAL_TB meal
    WHERE meal.MEMBER_FK = 4
      AND meal.CREATED_DATE >= '2024-06-01 00:00:00'
      AND meal.CREATED_DATE < '2024-07-01 00:00:00';
```

실행 계획

<img width="1150" alt="스크린샷 2024-08-06 오후 9 44 34" src="https://github.com/user-attachments/assets/cb780192-66c9-4b52-85ce-b3f785dcec63">

프로파일링
<img width="1350" alt="스크린샷 2024-08-06 오후 9 54 04" src="https://github.com/user-attachments/assets/adff129e-bae4-4dc6-9f4e-8efdf9a3b274">



**평균 : 약 0.00271s 경과**

MEMBER_FK(인덱스)를 사용해서 조회 및 엔티티를 반환하지 않기 때문에 메모리 절약

```sql
explain SELECT *
FROM MEAL_FOOD_TB MFT
    INNER JOIN FOOD_TB food ON MFT.FOOD_FK = food.FOOD_PK
WHERE MFT.MEAL_FK IN (
    ...
);
```
실행계획

<img width="1455" alt="스크린샷 2024-08-06 오후 9 54 29" src="https://github.com/user-attachments/assets/46e7e1f8-276e-4265-a757-ecfff9987fe3">

프로파일링

<img width="1427" alt="스크린샷 2024-08-06 오후 9 54 57" src="https://github.com/user-attachments/assets/e044a05e-89be-4fa2-b3cf-ed35b6a0a415">



**평균 : 0.00529s 경과**

MEAL_FOOD_TB에서 인덱스인 MEAL_FK를 사용하여, FOOD_TB에서는 PK인 FOOD_PK를 이용하여 조회한다.

## 결과

0.764s vs  0.00271s + 0.00529s + 애플리케이션 내 조립 및 EC2 <-> MariaDB 통신 시간

애플리케이션 내 조립 및 EC2 <-> MariaDB 통신 시간 측정이 필요합니다. 
다만, 쿼리 시간 차이가 많이 나서 결과에 영향을 줄 거 같지는 않습니다.

 
