### PR TITLE
[BE/FIX] 분석 조회 API 오류 수정

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealFoodRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealFoodRepository.java
@@ -20,6 +20,7 @@ public interface MealFoodRepository extends JpaRepository<MealFoodEntity, Long> 
     @Query("select mf from MealFoodEntity mf where mf.mealEntity.memberEntity = :memberEntity")
     List<MealFoodEntity> findByMemberEntity(MemberEntity memberEntity);
 
-    @Query("select mft from MealFoodEntity mft join fetch mft.foodEntity where mft.id in :ids")
+    @Query(
+            "select mft from MealFoodEntity mft join fetch mft.foodEntity where mft.mealEntity.id in :ids")
     List<MealFoodEntity> findMFTByIdInQuery(List<Long> ids);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzer.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import com.gaebaljip.exceed.application.domain.member.Member;
 import com.gaebaljip.exceed.common.annotation.Timer;
+import com.gaebaljip.exceed.common.exception.member.MemberNotFoundException;
 import com.gaebaljip.exceed.common.exception.nutritionist.MinimumMemberRequiredException;
 
 /**
@@ -43,15 +44,14 @@ public class MonthlyAnalyzer {
     }
 
     private Member getMemberByDate(LocalDate day, Map<LocalDate, Member> members) {
+        if (members.size() == 1) {
+            return members.entrySet().stream().findFirst().map(Map.Entry::getValue).get();
+        }
         return members.entrySet().stream()
                 .filter(entry -> entry.getKey().isAfter(day) || entry.getKey().equals(day))
                 .min(Map.Entry.comparingByKey())
                 .map(Map.Entry::getValue)
-                .orElse(members.get(getLastDate(day)));
-    }
-
-    private LocalDate getLastDate(LocalDate date) {
-        return date.withDayOfMonth(date.lengthOfMonth());
+                .orElseThrow(() -> MemberNotFoundException.EXECPTION);
     }
 
     private void validateAtLeastOneMember(Map<LocalDate, Member> members) {

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzer.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzer.java
@@ -44,7 +44,7 @@ public class MonthlyAnalyzer {
     }
 
     /**
-     * day와 비교해 가장 가까운 미래를 찾는다. 단, members의 size가 1인 경우는 day가 속한 달보다 과거의 날이다.
+     * day와 비교해 가장 가까운 미래를 찾는다. 단, members의 size가 1인 경우는 day가 속한 달보다 미래이다.
      *
      * @param day
      * @param members

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzer.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzer.java
@@ -43,6 +43,13 @@ public class MonthlyAnalyzer {
         return calorieAchievements;
     }
 
+    /**
+     * day와 비교해 가장 가까운 미래를 찾는다. 단, members의 size가 1인 경우는 day가 속한 달보다 과거의 날이다.
+     *
+     * @param day
+     * @param members
+     * @return
+     */
     private Member getMemberByDate(LocalDate day, Map<LocalDate, Member> members) {
         if (members.size() == 1) {
             return members.entrySet().stream().findFirst().map(Map.Entry::getValue).get();

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzerTest.java
@@ -17,7 +17,9 @@ import com.gaebaljip.exceed.common.factory.MonthlyMealFixtureFactory;
 
 class MonthlyAnalyzerTest {
     @Test
-    @DisplayName("MonthlyAnalyzer의 members 필드가 1개일 경우" + "membersMap의 key의 날짜가 now보다 40일전, 즉 무조건 한달 뒤를 보장")
+    @DisplayName(
+            "MonthlyAnalyzer의 members 필드가 1개일 경우"
+                    + "membersMap의 key의 날짜가 now보다 40일전, 즉 무조건 한달 뒤를 보장")
     void when_isCalorieAchievementByDate_expected_success() {
         LocalDateTime date = LocalDateTime.now();
         LocalDateTime startDateTime = date.with(TemporalAdjusters.firstDayOfMonth());

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/application/domain/nutritionist/MonthlyAnalyzerTest.java
@@ -1,0 +1,32 @@
+package com.gaebaljip.exceed.application.domain.nutritionist;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.gaebaljip.exceed.application.domain.member.Member;
+import com.gaebaljip.exceed.common.factory.MemberFixtureFactory;
+import com.gaebaljip.exceed.common.factory.MonthlyMealFixtureFactory;
+
+class MonthlyAnalyzerTest {
+    @Test
+    @DisplayName("MonthlyAnalyzer의 members 필드가 1개일 경우" + "membersMap의 key의 날짜가 now보다 40일전, 즉 무조건 한달 뒤를 보장")
+    void when_isCalorieAchievementByDate_expected_success() {
+        LocalDateTime date = LocalDateTime.now();
+        LocalDateTime startDateTime = date.with(TemporalAdjusters.firstDayOfMonth());
+        LocalDateTime endOfDateTime = date.with(TemporalAdjusters.lastDayOfMonth());
+        MonthlyMeal monthlyMeal = MonthlyMealFixtureFactory.create(startDateTime, endOfDateTime);
+        Member member = MemberFixtureFactory.create(1);
+        Map<LocalDate, Member> membersMap = new HashMap<>();
+        membersMap.put(startDateTime.toLocalDate().minusDays(40), member);
+        MonthlyAnalyzer monthlyAnalyzer = new MonthlyAnalyzer(monthlyMeal, membersMap);
+        assertDoesNotThrow(() -> monthlyAnalyzer.isCalorieAchievementByDate());
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MonthlyMealFixtureFactory.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/common/factory/MonthlyMealFixtureFactory.java
@@ -1,0 +1,36 @@
+package com.gaebaljip.exceed.common.factory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.gaebaljip.exceed.application.domain.meal.DailyMeal;
+import com.gaebaljip.exceed.application.domain.meal.Meal;
+import com.gaebaljip.exceed.application.domain.nutritionist.MonthlyMeal;
+
+public class MonthlyMealFixtureFactory {
+    public static MonthlyMeal create(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        List<Meal> meals =
+                MealsFixtureFactory.create(
+                        startDateTime.toLocalDate(), endDateTime.toLocalDate(), 40);
+        Map<LocalDate, DailyMeal> dailyMealMap =
+                meals.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        meal -> meal.getMealDateTime().toLocalDate(),
+                                        Collectors.collectingAndThen(
+                                                Collectors.toList(), DailyMeal::new)));
+
+        List<Meal> emptyMeal = new ArrayList<>();
+        startDateTime
+                .toLocalDate()
+                .datesUntil(endDateTime.toLocalDate())
+                .forEach(day -> dailyMealMap.putIfAbsent(day, new DailyMeal(emptyMeal)));
+
+        MonthlyMeal monthlyMeal = new MonthlyMeal(dailyMealMap);
+        return monthlyMeal;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/454

## 🔑 주요 변경사항

- findMFTByIdInQuery 메서드 쿼리 조건절 수정
- 회원 기록이 1개일 경우 고려하여 MontlyAnalyzer의 getMemberByDate 메서드 수정
- getMemberByDate 메서드 주석 추가
