### PR TITLE
[BE/PERF] 홈화면 API와 켈린더 상세 조회 API에 사용되는 쿼리 개선

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
@@ -57,7 +57,7 @@ public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyM
         LocalDateTime endOfMonth = date.with(TemporalAdjusters.firstDayOfNextMonth());
 
         List<Long> mealIds =
-                mealRepository.findMealsByMemberAndMonth(
+                mealRepository.findMealIdsByMemberAndMonth(
                         startOfMonth, endOfMonth, monthlyMealDTO.memberId());
         List<MealFoodEntity> mealFoodEntities = mealFoodRepository.findMFTByIdInQuery(mealIds);
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
@@ -43,7 +43,9 @@ public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyM
     public List<Meal> query(DailyMealDTO dailyMealDTO) {
         LocalDateTime today = dailyMealDTO.date().toLocalDate().atStartOfDay();
         LocalDateTime tomorrow = today.plusDays(1);
-        List<Long> mealIds = mealRepository.findMealIdsByMemberAndDaily(today, tomorrow, dailyMealDTO.memberId());
+        List<Long> mealIds =
+                mealRepository.findMealIdsByMemberAndDaily(
+                        today, tomorrow, dailyMealDTO.memberId());
         List<MealFoodEntity> mealFoodEntities = mealFoodRepository.findMFTByIdInQuery(mealIds);
         return mealFoodConverter.toMeals(mealFoodEntities);
     }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealPersistenceAdapter.java
@@ -30,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyMealPort {
 
     private final MealRepository mealRepository;
-    private final MealConverter mealConverter;
     private final MealFoodConverter mealFoodConverter;
     private final MealFoodRepository mealFoodRepository;
 
@@ -44,9 +43,9 @@ public class MealPersistenceAdapter implements MealPort, DailyMealPort, MonthlyM
     public List<Meal> query(DailyMealDTO dailyMealDTO) {
         LocalDateTime today = dailyMealDTO.date().toLocalDate().atStartOfDay();
         LocalDateTime tomorrow = today.plusDays(1);
-        List<MealEntity> mealEntities =
-                mealRepository.findAllTodayMeal(today, tomorrow, dailyMealDTO.memberId());
-        return mealConverter.toMeals(mealEntities);
+        List<Long> mealIds = mealRepository.findMealIdsByMemberAndDaily(today, tomorrow, dailyMealDTO.memberId());
+        List<MealFoodEntity> mealFoodEntities = mealFoodRepository.findMFTByIdInQuery(mealIds);
+        return mealFoodConverter.toMeals(mealFoodEntities);
     }
 
     @Override

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
@@ -21,7 +21,7 @@ public interface MealRepository extends JpaRepository<MealEntity, Long> {
     @Timer
     @Query(
             "select m.id from MealEntity m where m.memberEntity.id = :memberId and m.createdDate >= :startOfMonth and m.createdDate < :endOfMonth")
-    List<Long> findMealsByMemberAndMonth(
+    List<Long> findMealIdsByMemberAndMonth(
             LocalDateTime startOfMonth, LocalDateTime endOfMonth, Long memberId);
 
     void deleteByMemberEntity(MemberEntity memberEntity);

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
@@ -16,9 +16,8 @@ public interface MealRepository extends JpaRepository<MealEntity, Long> {
 
     @Query(
             "select m.id from MealEntity m where m.memberEntity.id = :memberId and m.createdDate >= :today and m.createdDate < :tomorrow")
-    List<Long> findMealIdsByMemberAndDaily(LocalDateTime today, LocalDateTime tomorrow, Long memberId);
-
-
+    List<Long> findMealIdsByMemberAndDaily(
+            LocalDateTime today, LocalDateTime tomorrow, Long memberId);
 
     @Timer
     @Query(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/jpa/meal/MealRepository.java
@@ -15,8 +15,10 @@ import com.gaebaljip.exceed.common.annotation.Timer;
 public interface MealRepository extends JpaRepository<MealEntity, Long> {
 
     @Query(
-            "select m from MealEntity m join fetch m.mealFoodEntity mf join fetch mf.foodEntity where m.createdDate >= :today and m.createdDate < :tomorrow and m.memberEntity.id = :memberId")
-    List<MealEntity> findAllTodayMeal(LocalDateTime today, LocalDateTime tomorrow, Long memberId);
+            "select m.id from MealEntity m where m.memberEntity.id = :memberId and m.createdDate >= :today and m.createdDate < :tomorrow")
+    List<Long> findMealIdsByMemberAndDaily(LocalDateTime today, LocalDateTime tomorrow, Long memberId);
+
+
 
     @Timer
     @Query(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/meal/GetCurrentMealService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/meal/GetCurrentMealService.java
@@ -3,7 +3,6 @@ package com.gaebaljip.exceed.application.service.meal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.gaebaljip.exceed.common.annotation.Timer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +10,7 @@ import com.gaebaljip.exceed.application.domain.meal.DailyMeal;
 import com.gaebaljip.exceed.application.domain.meal.Meal;
 import com.gaebaljip.exceed.application.port.in.meal.GetCurrentMealQuery;
 import com.gaebaljip.exceed.application.port.out.meal.DailyMealPort;
+import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.dto.CurrentMealDTO;
 import com.gaebaljip.exceed.common.dto.DailyMealDTO;
 import com.gaebaljip.exceed.common.exception.meal.NotSameDateException;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/CreateMemberService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/CreateMemberService.java
@@ -1,6 +1,5 @@
 package com.gaebaljip.exceed.application.service.member;
 
-import com.gaebaljip.exceed.common.annotation.Timer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +8,7 @@ import com.gaebaljip.exceed.adapter.in.member.request.SignUpMemberRequest;
 import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 import com.gaebaljip.exceed.application.port.in.member.CreateMemberUsecase;
 import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.exception.member.AlreadyEmailException;
 
 import lombok.RequiredArgsConstructor;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/ValidateEmailService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/ValidateEmailService.java
@@ -1,12 +1,12 @@
 package com.gaebaljip.exceed.application.service.member;
 
-import com.gaebaljip.exceed.common.annotation.Timer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.gaebaljip.exceed.application.port.in.member.ValidateEmailCommand;
 import com.gaebaljip.exceed.application.port.in.member.ValidateEmailUsecase;
 import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.exception.member.AlreadySignUpMemberException;
 
 import lombok.RequiredArgsConstructor;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/nutritionist/GetAllCalorieAnalysisService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/nutritionist/GetAllCalorieAnalysisService.java
@@ -2,7 +2,6 @@ package com.gaebaljip.exceed.application.service.nutritionist;
 
 import java.util.List;
 
-import com.gaebaljip.exceed.common.annotation.Timer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +13,7 @@ import com.gaebaljip.exceed.application.domain.nutritionist.*;
 import com.gaebaljip.exceed.application.port.in.nutritionist.GetAllAnalysisUsecase;
 import com.gaebaljip.exceed.application.port.out.meal.DailyMealPort;
 import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.dto.AllAnalysisDTO;
 import com.gaebaljip.exceed.common.dto.DailyMealDTO;
 


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/468

## 🔑 주요 변경사항

테이블의 인덱스를 잘 사용할 수 있는 방향으로 쿼리 분리

**기존 쿼리**

```sql
select m from MealEntity m join fetch m.mealFoodEntity mf join fetch mf.foodEntity where m.createdDate >= :today and m.createdDate < :tomorrow and m.memberEntity.id = :memberId
```

**변경 쿼리**

```sql
select m.id from MealEntity m where m.memberEntity.id = :memberId and m.createdDate >= :today and m.createdDate < :tomorrow

select mft from MealFoodEntity mft join fetch mft.foodEntity where mft.mealEntity.id in :ids
```

아래 PR에 수정한 쿼리와 완전히 동일한 형식의 쿼리이기 때문에 상세한 설명은 아래 PR로 대체

https://github.com/JNU-econovation/EATceed/pull/452

