### PR TITLE
[BE/FEAT] 비밀번호 변경 기능 

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/CheckMemberEmailController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/CheckMemberEmailController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import com.gaebaljip.exceed.adapter.in.member.request.CheckMemberRequest;
 import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
+import com.gaebaljip.exceed.application.port.in.member.UpdateCheckedUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.docs.member.CheckMemberEmailExceptionDocs;
@@ -27,8 +28,9 @@ public class CheckMemberEmailController {
 
     private final CheckCodeUsecase checkCodeUsecase;
     private final GetCodeUsecase getCodeUsecase;
+    private final UpdateCheckedUsecase updateCheckedUsecase;
 
-    @Value("${exceed.deepLink}")
+    @Value("${exceed.deepLink.signUp}")
     private String deepLink;
 
     @Operation(summary = "이메일 코드 확인", description = "해당 이메일의 인증 코드인지 확인한다.(딥링크로 들어간 화면에서 사용)")
@@ -36,12 +38,13 @@ public class CheckMemberEmailController {
     @ApiErrorExceptionsExample(CheckMemberEmailExceptionDocs.class)
     public ApiResponse<ApiResponse.CustomBody<Void>> checkMemberEmail(
             @RequestBody @Valid CheckMemberRequest checkMemberRequest) {
-        checkCodeUsecase.execute(checkMemberRequest);
+        checkCodeUsecase.execute(checkMemberRequest.email(), checkMemberRequest.code());
+        updateCheckedUsecase.execute(checkMemberRequest.email());
         return ApiResponseGenerator.success(HttpStatus.OK);
     }
 
     @Operation(summary = "링크 클릭시 리다이렉트", description = "AOS는 몰라도 되는 API")
-    @GetMapping("/email/redirect")
+    @GetMapping("/signUp-redirect")
     public void redirect(@RequestParam String email, HttpServletResponse response) {
         StringBuilder sb = new StringBuilder();
         String code = getCodeUsecase.execute(email);

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -1,0 +1,34 @@
+package com.gaebaljip.exceed.adapter.in.member;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import com.gaebaljip.exceed.adapter.in.member.request.SendEmailRequest;
+import com.gaebaljip.exceed.application.port.in.member.PasswordValidationUsecase;
+import com.gaebaljip.exceed.common.ApiResponse;
+import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
+import com.gaebaljip.exceed.common.ApiResponseGenerator;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1")
+@Tag(name = "[비밀번호 변경]")
+public class UpdatePasswordController {
+
+    private final PasswordValidationUsecase passwordValidationUsecase;
+    @Operation(
+            summary = "비밀번호 변경 전 이메일 검증 및 메일 전송",
+            description = "비밀번호 변경하기 전, 이메일 검증 및 이메일을 재전송한다.")
+    @PostMapping("/email")
+    public ApiResponse<CustomBody<Void>> validateEmail(
+            @RequestBody @Valid SendEmailRequest request) {
+        passwordValidationUsecase.execute(request.email());
+        return ApiResponseGenerator.success(HttpStatus.OK);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -7,6 +7,9 @@ import com.gaebaljip.exceed.adapter.in.member.request.UpdatePasswordRequest;
 import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
+import com.gaebaljip.exceed.common.docs.member.UpdatePassword_updatePasswordExceptionDocs;
+import com.gaebaljip.exceed.common.docs.member.UpdatePassword_validateEmailExceptionDocs;
+import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +41,7 @@ public class UpdatePasswordController {
             summary = "비밀번호 변경 전 이메일 검증 및 메일 전송",
             description = "비밀번호 변경하기 전, 이메일 검증 및 이메일을 재전송한다.")
     @PostMapping("/email")
+    @ApiErrorExceptionsExample(UpdatePassword_validateEmailExceptionDocs.class)
     public ApiResponse<CustomBody<Void>> validateEmail(
             @RequestBody @Valid SendEmailRequest request) {
         passwordValidationUsecase.execute(request.email());
@@ -57,6 +61,7 @@ public class UpdatePasswordController {
             summary = "비밀번호 찾기 및 변경",
             description = "비밀번호 변경시 사용하고, 비밀번호를 찾을 시에도 무조건 비밀번호를 변경한다.")
     @PatchMapping("/members/password")
+    @ApiErrorExceptionsExample(UpdatePassword_updatePasswordExceptionDocs.class)
     public ApiResponse<CustomBody<Void>> updatePassword(
             @RequestBody @Valid UpdatePasswordRequest request) {
         passwordValidationUsecase.execute(request.email());

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -1,7 +1,10 @@
 package com.gaebaljip.exceed.adapter.in.member;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
+import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +25,9 @@ import lombok.RequiredArgsConstructor;
 public class UpdatePasswordController {
 
     private final PasswordValidationUsecase passwordValidationUsecase;
+    private final GetCodeUsecase getCodeUsecase;
+    @Value("${exceed.deepLink.updatePassword}")
+    private String deepLink;
     @Operation(
             summary = "비밀번호 변경 전 이메일 검증 및 메일 전송",
             description = "비밀번호 변경하기 전, 이메일 검증 및 이메일을 재전송한다.")
@@ -31,4 +37,14 @@ public class UpdatePasswordController {
         passwordValidationUsecase.execute(request.email());
         return ApiResponseGenerator.success(HttpStatus.OK);
     }
+    @Operation(summary = "링크 클릭시 리다이렉트", description = "AOS는 몰라도 되는 API")
+    @GetMapping("/updatePassword-redirect")
+    public void redirect(@RequestParam String email, HttpServletResponse response) {
+        StringBuilder sb = new StringBuilder();
+        String code = getCodeUsecase.execute(email);
+        String redirectUrl = sb.append(deepLink).append("?code=").append(code).toString();
+        response.setHeader("Location", redirectUrl);
+        response.setStatus(302);
+    }
 }
+

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -3,7 +3,10 @@ package com.gaebaljip.exceed.adapter.in.member;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
+import com.gaebaljip.exceed.adapter.in.member.request.UpdatePasswordRequest;
+import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
+import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +31,9 @@ public class UpdatePasswordController {
     private final GetCodeUsecase getCodeUsecase;
     @Value("${exceed.deepLink.updatePassword}")
     private String deepLink;
+    private final CheckCodeUsecase checkCodeUsecase;
+    private final UpdatePasswordUsecase updatePasswordUsecase;
+
     @Operation(
             summary = "비밀번호 변경 전 이메일 검증 및 메일 전송",
             description = "비밀번호 변경하기 전, 이메일 검증 및 이메일을 재전송한다.")
@@ -37,6 +43,7 @@ public class UpdatePasswordController {
         passwordValidationUsecase.execute(request.email());
         return ApiResponseGenerator.success(HttpStatus.OK);
     }
+
     @Operation(summary = "링크 클릭시 리다이렉트", description = "AOS는 몰라도 되는 API")
     @GetMapping("/updatePassword-redirect")
     public void redirect(@RequestParam String email, HttpServletResponse response) {
@@ -45,6 +52,17 @@ public class UpdatePasswordController {
         String redirectUrl = sb.append(deepLink).append("?code=").append(code).toString();
         response.setHeader("Location", redirectUrl);
         response.setStatus(302);
+    }
+    @Operation(
+            summary = "비밀번호 찾기 및 변경",
+            description = "비밀번호 변경시 사용하고, 비밀번호를 찾을 시에도 무조건 비밀번호를 변경한다.")
+    @PatchMapping("/members/password")
+    public ApiResponse<CustomBody<Void>> updatePassword(
+            @RequestBody @Valid UpdatePasswordRequest request) {
+        passwordValidationUsecase.execute(request.email());
+        checkCodeUsecase.execute(request.email(), request.code());
+        updatePasswordUsecase.execute(request.email(), request.newPassword());
+        return ApiResponseGenerator.success(HttpStatus.OK);
     }
 }
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -3,22 +3,22 @@ package com.gaebaljip.exceed.adapter.in.member;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
-import com.gaebaljip.exceed.adapter.in.member.request.UpdatePasswordRequest;
-import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
-import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
-import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
-import com.gaebaljip.exceed.common.docs.member.UpdatePassword_updatePasswordExceptionDocs;
-import com.gaebaljip.exceed.common.docs.member.UpdatePassword_validateEmailExceptionDocs;
-import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import com.gaebaljip.exceed.adapter.in.member.request.SendEmailRequest;
+import com.gaebaljip.exceed.adapter.in.member.request.UpdatePasswordRequest;
+import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
+import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.PasswordValidationUsecase;
+import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
+import com.gaebaljip.exceed.common.docs.member.UpdatePassword_updatePasswordExceptionDocs;
+import com.gaebaljip.exceed.common.docs.member.UpdatePassword_validateEmailExceptionDocs;
+import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,8 +32,10 @@ public class UpdatePasswordController {
 
     private final PasswordValidationUsecase passwordValidationUsecase;
     private final GetCodeUsecase getCodeUsecase;
+
     @Value("${exceed.deepLink.updatePassword}")
     private String deepLink;
+
     private final CheckCodeUsecase checkCodeUsecase;
     private final UpdatePasswordUsecase updatePasswordUsecase;
 
@@ -57,6 +59,7 @@ public class UpdatePasswordController {
         response.setHeader("Location", redirectUrl);
         response.setStatus(302);
     }
+
     @Operation(
             summary = "비밀번호 찾기 및 변경",
             description = "비밀번호 변경시 사용하고, 비밀번호를 찾을 시에도 무조건 비밀번호를 변경한다.")
@@ -70,4 +73,3 @@ public class UpdatePasswordController {
         return ApiResponseGenerator.success(HttpStatus.OK);
     }
 }
-

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/SendEmailRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/SendEmailRequest.java
@@ -1,0 +1,7 @@
+package com.gaebaljip.exceed.adapter.in.member.request;
+
+import javax.validation.constraints.Email;
+
+import com.gaebaljip.exceed.common.ValidationMessage;
+
+public record SendEmailRequest(@Email(message = ValidationMessage.INVALID_EMAIL) String email) {}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdatePasswordRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdatePasswordRequest.java
@@ -1,0 +1,18 @@
+package com.gaebaljip.exceed.adapter.in.member.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import com.gaebaljip.exceed.common.ValidationMessage;
+import com.gaebaljip.exceed.common.annotation.Password;
+
+import lombok.Builder;
+
+public record UpdatePasswordRequest(
+        @Email(message = ValidationMessage.INVALID_EMAIL) String email,
+        @Password(message = ValidationMessage.INVALID_PASSWORD) String newPassword,
+        @NotBlank(message = "인증 코드를  " + ValidationMessage.NOT_BLANK) String code) {
+
+    @Builder
+    public UpdatePasswordRequest {}
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/redis/RedisAdapter.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/out/redis/RedisAdapter.java
@@ -25,4 +25,9 @@ public class RedisAdapter implements CodePort {
     public Optional<String> query(String email) {
         return Optional.ofNullable(redisUtils.getData(email));
     }
+
+    @Override
+    public void delete(String email) {
+        redisUtils.deleteData(email);
+    }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/member/MemberEntity.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/member/MemberEntity.java
@@ -74,6 +74,10 @@ public class MemberEntity extends BaseEntity {
         this.checked = true;
     }
 
+    public boolean isSignUp() {
+        return checked;
+    }
+
     public void updateMember(
             double height,
             Gender gender,

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/member/MemberEntity.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/member/MemberEntity.java
@@ -100,6 +100,10 @@ public class MemberEntity extends BaseEntity {
         this.targetWeight = targetWeight;
     }
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
     public boolean checkOnBoarding() {
         return this.getWeight() != null
                 && this.getHeight() != null

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/CheckCodeUsecase.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/CheckCodeUsecase.java
@@ -2,9 +2,7 @@ package com.gaebaljip.exceed.application.port.in.member;
 
 import org.springframework.stereotype.Component;
 
-import com.gaebaljip.exceed.adapter.in.member.request.CheckMemberRequest;
-
 @Component
 public interface CheckCodeUsecase {
-    void execute(CheckMemberRequest checkMemberRequest);
+    void execute(String email, String encrypt);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/PasswordValidationUsecase.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/PasswordValidationUsecase.java
@@ -1,0 +1,8 @@
+package com.gaebaljip.exceed.application.port.in.member;
+
+import com.gaebaljip.exceed.common.annotation.UseCase;
+
+@UseCase
+public interface PasswordValidationUsecase {
+    void execute(String email);
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/UpdateCheckedUsecase.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/UpdateCheckedUsecase.java
@@ -1,0 +1,8 @@
+package com.gaebaljip.exceed.application.port.in.member;
+
+import com.gaebaljip.exceed.common.annotation.UseCase;
+
+@UseCase
+public interface UpdateCheckedUsecase {
+    void execute(String email);
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/UpdatePasswordUsecase.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/UpdatePasswordUsecase.java
@@ -1,0 +1,8 @@
+package com.gaebaljip.exceed.application.port.in.member;
+
+import com.gaebaljip.exceed.common.annotation.UseCase;
+
+@UseCase
+public interface UpdatePasswordUsecase {
+    void execute(String email, String password);
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/member/CodePort.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/out/member/CodePort.java
@@ -9,4 +9,6 @@ public interface CodePort {
     void saveWithExpiration(String email, String code, Long expiredTime);
 
     Optional<String> query(String email);
+
+    void delete(String email);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/CheckCodeService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/CheckCodeService.java
@@ -3,11 +3,8 @@ package com.gaebaljip.exceed.application.service.member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.gaebaljip.exceed.adapter.in.member.request.CheckMemberRequest;
-import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
 import com.gaebaljip.exceed.application.port.out.member.CodePort;
-import com.gaebaljip.exceed.application.port.out.member.MemberPort;
 import com.gaebaljip.exceed.common.Encryption;
 import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.exception.member.ExpiredCodeException;
@@ -20,20 +17,13 @@ public class CheckCodeService implements CheckCodeUsecase {
 
     private final Encryption encryption;
     private final CodePort codePort;
-    private final MemberPort memberPort;
 
     @Override
     @Transactional
     @Timer
-    public void execute(CheckMemberRequest checkMemberRequest) {
-        String code =
-                codePort.query(checkMemberRequest.email())
-                        .orElseThrow(() -> ExpiredCodeException.EXECPTION);
-        String decrypt = encryption.decrypt(checkMemberRequest.code());
-        if (encryption.match(decrypt, code)) {
-            MemberEntity member = memberPort.findMemberByEmail(checkMemberRequest.email());
-            member.updateChecked();
-            codePort.delete(checkMemberRequest.email());
-        }
+    public void execute(String email, String encrypt) {
+        String code = codePort.query(email).orElseThrow(() -> ExpiredCodeException.EXECPTION);
+        String decrypt = encryption.decrypt(encrypt);
+        encryption.match(decrypt, code);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/CheckCodeService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/CheckCodeService.java
@@ -33,6 +33,7 @@ public class CheckCodeService implements CheckCodeUsecase {
         if (encryption.match(decrypt, code)) {
             MemberEntity member = memberPort.findMemberByEmail(checkMemberRequest.email());
             member.updateChecked();
+            codePort.delete(checkMemberRequest.email());
         }
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/PasswordValidationService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/PasswordValidationService.java
@@ -1,0 +1,32 @@
+package com.gaebaljip.exceed.application.service.member;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.gaebaljip.exceed.application.domain.member.MemberEntity;
+import com.gaebaljip.exceed.application.port.in.member.PasswordValidationUsecase;
+import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+import com.gaebaljip.exceed.common.annotation.EventPublisherStatus;
+import com.gaebaljip.exceed.common.event.Events;
+import com.gaebaljip.exceed.common.event.SendEmailEvent;
+import com.gaebaljip.exceed.common.exception.member.EmailNotVerifiedException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordValidationService implements PasswordValidationUsecase {
+
+    private final MemberPort memberPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    @EventPublisherStatus
+    public void execute(String email) {
+        MemberEntity member = memberPort.findMemberByEmail(email);
+        if (!member.isSignUp()) {
+            throw EmailNotVerifiedException.EXECPTION;
+        }
+        Events.raise(SendEmailEvent.of(email));
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/UpdateCheckedService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/UpdateCheckedService.java
@@ -1,0 +1,26 @@
+package com.gaebaljip.exceed.application.service.member;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.gaebaljip.exceed.application.domain.member.MemberEntity;
+import com.gaebaljip.exceed.application.port.in.member.UpdateCheckedUsecase;
+import com.gaebaljip.exceed.application.port.out.member.CodePort;
+import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateCheckedService implements UpdateCheckedUsecase {
+    private final CodePort codePort;
+    private final MemberPort memberPort;
+
+    @Override
+    @Transactional
+    public void execute(String email) {
+        MemberEntity member = memberPort.findMemberByEmail(email);
+        member.updateChecked();
+        codePort.delete(email);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/UpdatePasswordService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/UpdatePasswordService.java
@@ -1,0 +1,24 @@
+package com.gaebaljip.exceed.application.service.member;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.gaebaljip.exceed.application.domain.member.MemberEntity;
+import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
+import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdatePasswordService implements UpdatePasswordUsecase {
+
+    private final MemberPort memberPort;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Override
+    public void execute(String email, String password) {
+        MemberEntity member = memberPort.findMemberByEmail(email);
+        member.updatePassword(bCryptPasswordEncoder.encode(password));
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/ValidateSignUpService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/ValidateSignUpService.java
@@ -9,8 +9,8 @@ import com.gaebaljip.exceed.application.port.out.member.MemberPort;
 import com.gaebaljip.exceed.common.annotation.EventPublisherStatus;
 import com.gaebaljip.exceed.common.event.Events;
 import com.gaebaljip.exceed.common.event.IncompleteSignUpEvent;
-import com.gaebaljip.exceed.common.exception.member.AlreadyEmailException;
 import com.gaebaljip.exceed.common.exception.member.AlreadySignUpMemberException;
+import com.gaebaljip.exceed.common.exception.member.EmailNotVerifiedException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,6 +33,6 @@ public class ValidateSignUpService implements ValidateSignUpUsecase {
             throw AlreadySignUpMemberException.EXECPTION;
         }
         Events.raise(IncompleteSignUpEvent.from(command.email(), command.password()));
-        throw AlreadyEmailException.EXECPTION;
+        throw EmailNotVerifiedException.EXECPTION;
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/Encryption.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/Encryption.java
@@ -3,7 +3,6 @@ package com.gaebaljip.exceed.common;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
@@ -11,7 +10,6 @@ import java.util.Objects;
 import javax.annotation.PostConstruct;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
-import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -35,13 +33,12 @@ public class Encryption {
     private String secret;
 
     private SecretKeySpec secretKeySpec;
-    private IvParameterSpec ivParameterSpec;
     private Cipher cipher;
 
     @Timer
     public String encrypt(String value) {
         try {
-            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
             byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8); // String을 바이트 배열로 변환
             byte[] encrypted = cipher.doFinal(valueBytes);
             return Base64.getUrlEncoder().encodeToString(encrypted);
@@ -53,7 +50,7 @@ public class Encryption {
     @Timer
     public String decrypt(final String encryptedValue) {
         try {
-            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
             byte[] encryptedBytes = Base64.getUrlDecoder().decode(encryptedValue);
             byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
             return new String(decryptedBytes, StandardCharsets.UTF_8); // 바이트 배열을 String으로 변환
@@ -71,17 +68,11 @@ public class Encryption {
 
     @PostConstruct
     public void init() throws NoSuchPaddingException, NoSuchAlgorithmException {
-        SecureRandom secureRandom = new SecureRandom();
-        byte[] iv = new byte[16]; // 16bytes = 128bits
-        secureRandom.nextBytes(iv);
-        ivParameterSpec = new IvParameterSpec(iv);
-
         byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
         MessageDigest sha = MessageDigest.getInstance("SHA-256");
         keyBytes = sha.digest(keyBytes);
         keyBytes = Arrays.copyOf(keyBytes, 16); // AES-128을 위한 16바이트 키
         secretKeySpec = new SecretKeySpec(keyBytes, algorithm);
-
         cipher = Cipher.getInstance(encryptionSpec);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
@@ -2,9 +2,14 @@ package com.gaebaljip.exceed.common;
 
 public class MailTemplate {
     public static final String SIGN_UP_TEMPLATE = "signup";
+    public static final String UPDATE_PASSWORD_TEMPLATE = "updatePassword";
 
     public static final String SIGN_UP_TITLE = "Eatceed 회원가입 인증 메일";
+    public static final String UPDATE_PASSWORD_TITLE = "Eatceed 비밀번호 변경 메일";
     public static final String SIGN_UP_MAIL_CONTEXT = "signupLink";
+    public static final String UPDATE_PASSWORD_MAIL_CONTEXT = "updatePasswordLink";
     public static final String SIGN_UP_EMAIL = "email";
-    public static final String REPLY_TO_SIGN_UP_MAIL_URL = "/v1/email/redirect";
+    public static final String UPDATE_PASSWORD_EMAIL = "email";
+    public static final String REPLY_TO_SIGN_UP_MAIL_URL = "/v1/signUp-redirect";
+    public static final String REPLY_TO_UPDATE_PASSWORD_MAIL_URL = "/v1/updatePassword-redirect";
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/SignUpMemberExceptionDocs.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/SignUpMemberExceptionDocs.java
@@ -3,8 +3,8 @@ package com.gaebaljip.exceed.common.docs.member;
 import com.gaebaljip.exceed.common.exception.DecryptionErrorException;
 import com.gaebaljip.exceed.common.exception.EatCeedException;
 import com.gaebaljip.exceed.common.exception.EncryptionErrorException;
-import com.gaebaljip.exceed.common.exception.member.AlreadyEmailException;
 import com.gaebaljip.exceed.common.exception.member.AlreadySignUpMemberException;
+import com.gaebaljip.exceed.common.exception.member.EmailNotVerifiedException;
 import com.gaebaljip.exceed.common.exception.member.MailSendException;
 import com.gaebaljip.exceed.common.swagger.ExceptionDoc;
 import com.gaebaljip.exceed.common.swagger.ExplainError;
@@ -17,7 +17,7 @@ public class SignUpMemberExceptionDocs implements SwaggerExampleExceptions {
     public EatCeedException 이미_회원가입된_회원일_때 = AlreadySignUpMemberException.EXECPTION;
 
     @ExplainError("이메일 인증을 하지 않았을 때")
-    public EatCeedException 이메일_인증을_하지_않았을_때 = AlreadyEmailException.EXECPTION;
+    public EatCeedException 이메일_인증을_하지_않았을_때 = EmailNotVerifiedException.EXECPTION;
 
     @ExplainError("암호화 실패 시")
     public EatCeedException 암호화_실패_시 = EncryptionErrorException.EXECPTION;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePassword_updatePasswordExceptionDocs.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePassword_updatePasswordExceptionDocs.java
@@ -1,0 +1,22 @@
+package com.gaebaljip.exceed.common.docs.member;
+
+import com.gaebaljip.exceed.common.exception.EatCeedException;
+import com.gaebaljip.exceed.common.exception.member.EmailNotVerifiedException;
+import com.gaebaljip.exceed.common.exception.member.ExpiredCodeException;
+import com.gaebaljip.exceed.common.exception.member.MemberNotFoundException;
+import com.gaebaljip.exceed.common.swagger.ExceptionDoc;
+import com.gaebaljip.exceed.common.swagger.ExplainError;
+import com.gaebaljip.exceed.common.swagger.SwaggerExampleExceptions;
+@ExceptionDoc
+public class UpdatePassword_updatePasswordExceptionDocs implements SwaggerExampleExceptions {
+
+    @ExplainError("회원이 존재하지 않을 때")
+    public EatCeedException 회원이_존재하지_않을_때 = MemberNotFoundException.EXECPTION;
+
+    @ExplainError("이메일 인증을 수행하지 않은 회원일 때")
+    public EatCeedException 이메일인증을_수행하지_않고_비밀번호_변경을_시도할때 = EmailNotVerifiedException.EXECPTION;
+
+    @ExplainError("잘못된(혹은 만료된) 인증 코들일 경우")
+    public EatCeedException 잘못된_인증코드일_경우 = ExpiredCodeException.EXECPTION;
+
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePassword_updatePasswordExceptionDocs.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePassword_updatePasswordExceptionDocs.java
@@ -7,6 +7,7 @@ import com.gaebaljip.exceed.common.exception.member.MemberNotFoundException;
 import com.gaebaljip.exceed.common.swagger.ExceptionDoc;
 import com.gaebaljip.exceed.common.swagger.ExplainError;
 import com.gaebaljip.exceed.common.swagger.SwaggerExampleExceptions;
+
 @ExceptionDoc
 public class UpdatePassword_updatePasswordExceptionDocs implements SwaggerExampleExceptions {
 
@@ -18,5 +19,4 @@ public class UpdatePassword_updatePasswordExceptionDocs implements SwaggerExampl
 
     @ExplainError("잘못된(혹은 만료된) 인증 코들일 경우")
     public EatCeedException 잘못된_인증코드일_경우 = ExpiredCodeException.EXECPTION;
-
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePassword_validateEmailExceptionDocs.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePassword_validateEmailExceptionDocs.java
@@ -1,0 +1,18 @@
+package com.gaebaljip.exceed.common.docs.member;
+
+import com.gaebaljip.exceed.common.exception.EatCeedException;
+import com.gaebaljip.exceed.common.exception.member.EmailNotVerifiedException;
+import com.gaebaljip.exceed.common.exception.member.MemberNotFoundException;
+import com.gaebaljip.exceed.common.swagger.ExceptionDoc;
+import com.gaebaljip.exceed.common.swagger.ExplainError;
+import com.gaebaljip.exceed.common.swagger.SwaggerExampleExceptions;
+
+@ExceptionDoc
+public class UpdatePassword_validateEmailExceptionDocs implements SwaggerExampleExceptions {
+
+    @ExplainError("회원이 존재하지 않을 때")
+    public EatCeedException 회원이_존재하지_않을_때 = MemberNotFoundException.EXECPTION;
+
+    @ExplainError("이메일 인증을 수행하지 않은 회원일 때")
+    public EatCeedException 이메일인증을_수행하지_않고_비밀번호_변경을_시도할때 = EmailNotVerifiedException.EXECPTION;
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/IncompleteSignUpEvent.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/IncompleteSignUpEvent.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class IncompleteSignUpEvent extends DomainEvent {
+public class IncompleteSignUpEvent extends InfraEvent {
     private String email;
     private String password;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/SendEmailEvent.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/SendEmailEvent.java
@@ -1,0 +1,14 @@
+package com.gaebaljip.exceed.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SendEmailEvent extends InfraEvent {
+    private final String email;
+
+    public static SendEmailEvent of(String email) {
+        return new SendEmailEvent(email);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/SignUpMemberEvent.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/SignUpMemberEvent.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class SignUpMemberEvent extends DomainEvent {
+public class SignUpMemberEvent extends InfraEvent {
 
     private String email;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
@@ -1,0 +1,46 @@
+package com.gaebaljip.exceed.common.event.handler;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.thymeleaf.context.Context;
+
+import com.gaebaljip.exceed.application.domain.member.Code;
+import com.gaebaljip.exceed.application.port.out.member.CodePort;
+import com.gaebaljip.exceed.application.port.out.member.EmailPort;
+import com.gaebaljip.exceed.common.MailTemplate;
+import com.gaebaljip.exceed.common.event.SendEmailEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SendEmailEventListener {
+    private final EmailPort emailPort;
+    private final CodePort codePort;
+
+    @Value("${exceed.url}")
+    private String URL;
+
+    private Long expiredTime = 600000L;
+
+    @TransactionalEventListener(classes = SendEmailEvent.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
+    public void handle(SendEmailEvent event) {
+        codePort.saveWithExpiration(event.getEmail(), Code.create(), expiredTime);
+        Context context = new Context();
+        context.setVariable(
+                MailTemplate.UPDATE_PASSWORD_MAIL_CONTEXT,
+                URL + MailTemplate.REPLY_TO_UPDATE_PASSWORD_MAIL_URL);
+        context.setVariable(MailTemplate.UPDATE_PASSWORD_EMAIL, "?email=" + event.getEmail());
+        emailPort.sendEmail(
+                event.getEmail(),
+                MailTemplate.UPDATE_PASSWORD_TITLE,
+                MailTemplate.UPDATE_PASSWORD_TEMPLATE,
+                context);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/EmailNotVerifiedException.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/EmailNotVerifiedException.java
@@ -5,11 +5,11 @@ import com.gaebaljip.exceed.common.exception.EatCeedException;
 import lombok.Getter;
 
 @Getter
-public class AlreadyEmailException extends EatCeedException {
+public class EmailNotVerifiedException extends EatCeedException {
 
-    public static EatCeedException EXECPTION = new AlreadyEmailException();
+    public static EatCeedException EXECPTION = new EmailNotVerifiedException();
 
-    public AlreadyEmailException() {
+    public EmailNotVerifiedException() {
         super(MemberError.ALREADY_EMAIL);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/MemberError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/MemberError.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum MemberError implements BaseError {
     ALREADY_SIGN_UP_MEMBER(400, "4449", "이미 회원가입이 된 이메일입니다."),
-    ALREADY_EMAIL(400, "4448", "이미 해당 메일로 가입된 계정이 있습니다, 이메일 인증을 해주세요."),
+    ALREADY_EMAIL(400, "4448", "이메일 인증을 하지 않은 회원입니다."),
     INVALID_AGE(400, "4446", "나이는 음수일 수 없습니다."),
     INVALID_CODE(400, "7003", "올바르지 않은 인증 코드이거나 만료된 인증코드입니다. 이메일 재전송을 해주세요."),
     INVALID_GENDER(400, "4447", "성별은 1과 0으로만 표현됩니다."),

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
@@ -73,13 +73,14 @@ public class SecurityConfig {
                         "/v1/members/email/checked",
                         "/actuator/**",
                         "/v1/health",
-                        "/v1/email/redirect")
+                        "/v1//updatePassword-redirect",
+                        "/v1/signUp-redirect")
                 .permitAll()
                 .antMatchers(HttpMethod.PUT, "/v1/members/email/confirmed")
                 .permitAll()
-                .antMatchers(HttpMethod.PATCH, "/v1/members/checked")
+                .antMatchers(HttpMethod.PATCH, "/v1/members/checked", "/v1/members/password")
                 .permitAll()
-                .antMatchers(HttpMethod.POST, "/v1/members")
+                .antMatchers(HttpMethod.POST, "/v1/members", "/v1/email")
                 .permitAll()
                 .antMatchers(HttpMethod.POST, "/v1/auth/login")
                 .permitAll()

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
@@ -70,7 +70,6 @@ public class SecurityConfig {
                 .permitAll()
                 .antMatchers(
                         HttpMethod.GET,
-                        "/v1/members/checked/**",
                         "/v1/members/email/checked",
                         "/actuator/**",
                         "/v1/health",

--- a/BE/exceed/src/main/resources/application-dev.yml
+++ b/BE/exceed/src/main/resources/application-dev.yml
@@ -41,8 +41,8 @@ jwt:
 exceed:
   url : https://eatceed.net
   deepLink :
-    signUp : eatceed://deeplink
-    updatePassword : eatceed://deeplink2
+    signUp: eatceed://checkemail
+    updatePassword: eatceed://changepw
 
 springdoc:
   api-docs:

--- a/BE/exceed/src/main/resources/application-dev.yml
+++ b/BE/exceed/src/main/resources/application-dev.yml
@@ -40,7 +40,9 @@ jwt:
 
 exceed:
   url : https://eatceed.net
-  deepLink : eatceed://deeplink
+  deepLink :
+    signUp : eatceed://deeplink
+    updatePassword : eatceed://deeplink2
 
 springdoc:
   api-docs:

--- a/BE/exceed/src/main/resources/application-local.yml
+++ b/BE/exceed/src/main/resources/application-local.yml
@@ -42,7 +42,9 @@ jwt:
 
 exceed:
   url : http://localhost:8080
-  deepLink : eatceed://deeplink
+  deepLink :
+    signUp : eatceed://checkemail
+    updatePassword : eatceed://changepw
 
 # swagger
 springdoc:

--- a/BE/exceed/src/main/resources/application-prod.yml
+++ b/BE/exceed/src/main/resources/application-prod.yml
@@ -41,8 +41,8 @@ jwt:
 exceed:
   url : https://eatceed.net
   deepLink :
-    signUp : eatceed://deeplink
-    updatePassword : eatceed://deeplink2
+    signUp: eatceed://checkemail
+    updatePassword: eatceed://changepw
 
 springdoc:
   api-docs:

--- a/BE/exceed/src/main/resources/application-prod.yml
+++ b/BE/exceed/src/main/resources/application-prod.yml
@@ -40,7 +40,9 @@ jwt:
 
 exceed:
   url : https://eatceed.net
-  deepLink : eatceed://deeplink
+  deepLink :
+    signUp : eatceed://deeplink
+    updatePassword : eatceed://deeplink2
 
 springdoc:
   api-docs:

--- a/BE/exceed/src/main/resources/application-test.yml
+++ b/BE/exceed/src/main/resources/application-test.yml
@@ -33,8 +33,8 @@ cloud:
 exceed:
   url : http://loaclhost:8080
   deepLink :
-    signUp : eatceed://deeplink
-    updatePassword : eatceed://deeplink2
+    signUp: eatceed://checkemail
+    updatePassword: eatceed://changepw
 
 
 encryption:

--- a/BE/exceed/src/main/resources/application-test.yml
+++ b/BE/exceed/src/main/resources/application-test.yml
@@ -31,8 +31,10 @@ cloud:
       # mode: always
 
 exceed:
-  url : http://localhost:8080
-  deepLink : eatceed://deeplink
+  url : http://loaclhost:8080
+  deepLink :
+    signUp : eatceed://deeplink
+    updatePassword : eatceed://deeplink2
 
 
 encryption:

--- a/BE/exceed/src/main/resources/templates/updatePassword.html
+++ b/BE/exceed/src/main/resources/templates/updatePassword.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Eatceed 비밀번호 변경</title>
+</head>
+<body>
+<h2>비밀번호 변경</h2>
+<p>안녕하세요 체중 증량 어플 Eatceed입니다.</p>
+<p>아래의 링크를 클릭해 비밀번호 변경 페이지로 이동해주세요.</p>
+<p>인증을 요청하지 않았다면, 이 이메일을 무시하셔도 됩니다.</p>
+<a th:href="${updatePasswordLink} + ${email}">비밀번호 변경 링크</a>
+<link rel="shortcut icon" type="image/x-icon" href="data:image/x-icon;," >
+</body>
+</html>

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/application/member/ValidateSignUpServiceTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/application/member/ValidateSignUpServiceTest.java
@@ -13,11 +13,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.gaebaljip.exceed.application.port.in.member.ValidateSignUpCommand;
 import com.gaebaljip.exceed.application.port.out.member.MemberPort;
 import com.gaebaljip.exceed.application.service.member.ValidateSignUpService;
-import com.gaebaljip.exceed.common.exception.member.AlreadyEmailException;
 import com.gaebaljip.exceed.common.exception.member.AlreadySignUpMemberException;
+import com.gaebaljip.exceed.common.exception.member.EmailNotVerifiedException;
 
 @ExtendWith(MockitoExtension.class)
-class ValidateEmailServiceTest {
+class ValidateSignUpServiceTest {
 
     @Mock private MemberPort memberPort;
     @InjectMocks private ValidateSignUpService validateEmailService;
@@ -45,7 +45,7 @@ class ValidateEmailServiceTest {
 
         // when, then
         Assertions.assertThrows(
-                AlreadyEmailException.class, () -> validateEmailService.execute(command));
+                EmailNotVerifiedException.class, () -> validateEmailService.execute(command));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed/issues/491

## 🔑 주요 변경사항

- 비밀번호 변경 전 이메일을 전송하여 본인의 이메일인지 확인하는 API 개발 - UpdatePasswordController의 validateEmail() 
- 이메일 링크 클릭시 딥링크로 리다이렉트 되는 API 개발
- 비밀번호 수정하는 API 개발 (비밀번호 변경할 때도 동일한 API 사용)
