### PR TITLE
[BE/FIX] 도메인이 달라서 쿠키 안담기는 오류 

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/auth/AuthController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/auth/AuthController.java
@@ -65,7 +65,11 @@ public class AuthController {
         TokenDTO reissueTokenDTO =
                 authUsecase.reIssueToken(accessToken, refreshToken, httpRequestDTO);
         response.setHeader(AuthConstants.AUTH_HEADER.getValue(), reissueTokenDTO.accessToken());
-        setCookie(response, EatCeedStaticMessage.REFRESH_TOKEN, reissueTokenDTO.refreshToken(), maxAge);
+        setCookie(
+                response,
+                EatCeedStaticMessage.REFRESH_TOKEN,
+                reissueTokenDTO.refreshToken(),
+                maxAge);
         return ApiResponseGenerator.success(HttpStatus.OK);
     }
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/DecryptionErrorException.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/DecryptionErrorException.java
@@ -8,6 +8,6 @@ public class DecryptionErrorException extends EatCeedException {
     public static EatCeedException EXECPTION = new DecryptionErrorException();
 
     public DecryptionErrorException() {
-        super(EncryptionError.DECRYPTION_FAIL);
+        super(GlobalError.DECRYPTION_FAIL);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/EncryptionErrorException.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/EncryptionErrorException.java
@@ -8,6 +8,6 @@ public class EncryptionErrorException extends EatCeedException {
     public static EatCeedException EXECPTION = new EncryptionErrorException();
 
     public EncryptionErrorException() {
-        super(EncryptionError.ENCRYPTION_FAIL);
+        super(GlobalError.ENCRYPTION_FAIL);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalError.java
@@ -15,7 +15,6 @@ public enum GlobalError implements BaseError {
     ENCRYPTION_FAIL(500, "ENCRYPTION_500_1", "암호화에 실패하였습니다."),
     DECRYPTION_FAIL(500, "ENCRYPTION_500_2", "복호화에 실패하였습니다."),
     EXTENTION_NOT_ALLOWED(400, "GLOBAL_400_1", "이미지의 확장자는 jpg, jpeg, png만 가능합니다."),
-
     ;
 
     private final Integer status;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalError.java
@@ -11,9 +11,12 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum EncryptionError implements BaseError {
-    ENCRYPTION_FAIL(500, "8001", "암호화에 실패하였습니다."),
-    DECRYPTION_FAIL(500, "8002", "복호화에 실패하였습니다.");
+public enum GlobalError implements BaseError {
+    ENCRYPTION_FAIL(500, "ENCRYPTION_500_1", "암호화에 실패하였습니다."),
+    DECRYPTION_FAIL(500, "ENCRYPTION_500_2", "복호화에 실패하였습니다."),
+    EXTENTION_NOT_ALLOWED(400, "GLOBAL_400_1", "이미지의 확장자는 jpg, jpeg, png만 가능합니다."),
+
+    ;
 
     private final Integer status;
     private final String code;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/auth/AuthError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/auth/AuthError.java
@@ -13,9 +13,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthError implements BaseError {
-    PASSWORD_MISMATCH(400, "5003", "비밀번호가 일치하지 않습니다."),
-    MEMBER_NOT_CHECKED(400, "5004", "해당 회원은 이메일 검증이 완료되지 않았습니다."),
-    NOT_FOUND_REFRESHTOKEN(400, "5005", "리프레시 토큰이 존재하지 않습니다.");
+    PASSWORD_MISMATCH(400, "AUTH_400_1", "비밀번호가 일치하지 않습니다."),
+    MEMBER_NOT_CHECKED(400, "AUTH_400_2", "해당 회원은 이메일 검증이 완료되지 않았습니다."),
+    NOT_FOUND_REFRESHTOKEN(400, "AUTH_400_3", "리프레시 토큰이 존재하지 않습니다.");
 
     private final Integer status;
     private final String code;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/food/FoodError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/food/FoodError.java
@@ -13,8 +13,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum FoodError implements BaseError {
-    INVALID_FOOD(400, "4450", "존재하지 않는 음식입니다."),
-    CANNOT_DELETE_OTHERS_FOOD(400, "4451", "다른 사람의 음식은 삭제할 수 없습니다."),
+    INVALID_FOOD(400, "FOOD_400_1", "존재하지 않는 음식입니다."),
+    CANNOT_DELETE_OTHERS_FOOD(400, "FOOD_400_2", "다른 사람의 음식은 삭제할 수 없습니다."),
     ;
 
     private final Integer status;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/ExtentionNotAllowedException.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/ExtentionNotAllowedException.java
@@ -1,8 +1,8 @@
 package com.gaebaljip.exceed.common.exception.meal;
 
 import com.gaebaljip.exceed.common.exception.EatCeedException;
-
 import com.gaebaljip.exceed.common.exception.GlobalError;
+
 import lombok.Getter;
 
 @Getter

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/ExtentionNotAllowedException.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/ExtentionNotAllowedException.java
@@ -2,6 +2,7 @@ package com.gaebaljip.exceed.common.exception.meal;
 
 import com.gaebaljip.exceed.common.exception.EatCeedException;
 
+import com.gaebaljip.exceed.common.exception.GlobalError;
 import lombok.Getter;
 
 @Getter
@@ -9,6 +10,6 @@ public class ExtentionNotAllowedException extends EatCeedException {
     public static EatCeedException EXECPTION = new ExtentionNotAllowedException();
 
     private ExtentionNotAllowedException() {
-        super(MealError.EXTENTION_NOT_ALLOWED);
+        super(GlobalError.EXTENTION_NOT_ALLOWED);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/MealError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/meal/MealError.java
@@ -13,16 +13,15 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum MealError implements BaseError {
-    EXTENTION_NOT_ALLOWED(400, "4452", "이미지의 확장자는 jpg, jpeg, png만 가능합니다."),
-    INSUFFICIENT_MEALS(400, "6000", "하루 식사는 최소 한 끼 이상 제공되어야 합니다."),
-    INVALID_MULTIPLE(400, "4449", "0인분보다 커야하고, 100인분보다 작아야합니다."),
-    NOT_SAME_DATE(400, "6001", "하루 식사는 같은 날짜입니다."),
+    INSUFFICIENT_MEALS(400, "MEAL_400_1", "하루 식사는 최소 한 끼 이상 제공되어야 합니다."),
+    INVALID_MULTIPLE(400, "MEAL_400_2", "0인분보다 커야하고, 100인분보다 작아야합니다."),
+    NOT_SAME_DATE(400, "MEAL_400_3", "하루 식사는 같은 날짜입니다."),
     INVALID_MULTIPLE_AND_G(
             400,
-            "6002",
+            "MEAL_400_4",
             "'multiple'은 null이 아니고 'g'는 null이어야 하거나, 'multiple'은 null이고 'g'는 null이 아니어야 합니다."),
-    INVALID_G(400, "6002", "g은 1 이상이어야합니다."),
-    INVALID_DATE_FOUND(400, "6321", "회원가입 이전의 기록은 없습니다.");
+    INVALID_G(400, "MEAL_400_5", "g은 1 이상이어야합니다."),
+    INVALID_DATE_FOUND(400, "MEAL_400_6", "회원가입 이전의 기록은 없습니다.");
 
     private final Integer status;
     private final String code;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/MemberError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/MemberError.java
@@ -13,16 +13,16 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum MemberError implements BaseError {
-    ALREADY_SIGN_UP_MEMBER(400, "4449", "이미 회원가입이 된 이메일입니다."),
-    ALREADY_EMAIL(400, "4448", "이메일 인증을 하지 않은 회원입니다."),
-    INVALID_AGE(400, "4446", "나이는 음수일 수 없습니다."),
-    INVALID_CODE(400, "7003", "올바르지 않은 인증 코드이거나 만료된 인증코드입니다. 이메일 재전송을 해주세요."),
-    INVALID_GENDER(400, "4447", "성별은 1과 0으로만 표현됩니다."),
-    INVALID_HEIGHT(400, "4444", "키는 음수일 수 없습니다."),
-    INVALID_WEIGHT(400, "4445", "몸무게가 음수일 수 없습니다."),
-    MAIL_SEND_FAIL(400, "7002", "메일 전송에 실패하였습니다."),
-    INVALID_MEMBER(400, "4448", "존재하지 않는 회원입니다."),
-    HISTORY_NOT_FOUND(500, "5555", "첫 온보딩하기 전입니다.");
+    ALREADY_SIGN_UP_MEMBER(400, "MEMBER_400_1", "이미 회원가입이 된 이메일입니다."),
+    ALREADY_EMAIL(400, "MEMBER_400_2", "이메일 인증을 하지 않은 회원입니다."),
+    INVALID_AGE(400, "MEMBER_400_3", "나이는 음수일 수 없습니다."),
+    INVALID_CODE(400, "MEMBER_400_4", "올바르지 않은 인증 코드이거나 만료된 인증코드입니다. 이메일 재전송을 해주세요."),
+    INVALID_GENDER(400, "MEMBER_400_5", "성별은 1과 0으로만 표현됩니다."),
+    INVALID_HEIGHT(400, "MEMBER_400_6", "키는 음수일 수 없습니다."),
+    INVALID_WEIGHT(400, "MEMBER_400_7", "몸무게가 음수일 수 없습니다."),
+    MAIL_SEND_FAIL(400, "MEMBER_400_8", "메일 전송에 실패하였습니다."),
+    INVALID_MEMBER(400, "MEMBER_400_9", "존재하지 않는 회원입니다."),
+    HISTORY_NOT_FOUND(500, "MEMBER_500_1", "첫 온보딩하기 전입니다.");
     private final Integer status;
     private final String code;
     private final String reason;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/nutritionist/NutritionistError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/nutritionist/NutritionistError.java
@@ -13,10 +13,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum NutritionistError implements BaseError {
-    INVALID_MEAL(400, "4451", "존재하지 않는 식사입니다."),
-    NOT_SAME_YEAR_MONTH(500, "4452", "모든 날짜의 연도와 월은 같아야합니다."),
-    NOT_SAME_SIZE(500, "4452", "해당 월의 일수와 size가 같아야합니다."),
-    NOT_REQUIRED_MINIMUM_MEMBER(500, "4452", "회원이 1개 이상 있어야합니다.");
+    INVALID_MEAL(400, "NUTRITIONIST_400_1", "존재하지 않는 식사입니다."),
+    NOT_SAME_YEAR_MONTH(500, "NUTRITIONIST_500_1", "모든 날짜의 연도와 월은 같아야합니다."),
+    NOT_SAME_SIZE(500, "NUTRITIONIST_500_2", "해당 월의 일수와 size가 같아야합니다."),
+    NOT_REQUIRED_MINIMUM_MEMBER(500, "NUTRITIONIST_500_3", "회원이 1개 이상 있어야합니다.");
 
     private final Integer status;
     private final String code;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/exception/SecurityErrorCode.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/exception/SecurityErrorCode.java
@@ -13,11 +13,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SecurityErrorCode implements BaseError {
-    INVALID_JWT(401, "5000", "잘못된 토큰입니다."),
-    EXPIRED_JWT(401, "5001", "만료된 토큰입니다."),
-    UNSUPPORTED_JWT(401, "5002", "지원되지 않는 토큰입니다."),
-    SIGNATURE_JWT(401, "5003", "토큰의 형식이 잘못 됬습니다."),
-    NEED_AUTHENTICATION(401, "5004", "인증이 필요합니다.");
+    INVALID_JWT(401, "SECURITY_401_1", "잘못된 토큰입니다."),
+    EXPIRED_JWT(401, "SECURITY_401_2", "만료된 토큰입니다."),
+    UNSUPPORTED_JWT(401, "SECURITY_401_3", "지원되지 않는 토큰입니다."),
+    SIGNATURE_JWT(401, "SECURITY_401_4", "토큰의 형식이 잘못 됬습니다."),
+    NEED_AUTHENTICATION(401, "SECURITY_401_5", "인증이 필요합니다.");
 
     private final Integer status;
     private final String code;

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/meal/GetMealIntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/meal/GetMealIntegrationTest.java
@@ -29,6 +29,8 @@ import com.gaebaljip.exceed.common.IntegrationTest;
 import com.gaebaljip.exceed.common.WithMockUser;
 import com.gaebaljip.exceed.common.dto.AllAnalysisDTO;
 import com.gaebaljip.exceed.common.dto.MealRecordDTO;
+import com.gaebaljip.exceed.common.exception.meal.MealError;
+import com.gaebaljip.exceed.common.exception.member.MemberError;
 
 @InitializeS3Bucket
 public class GetMealIntegrationTest extends IntegrationTest {
@@ -166,7 +168,9 @@ public class GetMealIntegrationTest extends IntegrationTest {
                         RestDocumentationRequestBuilders.get("/v1/meal/" + testData)
                                 .contentType(MediaType.APPLICATION_JSON));
 
-        resultActions.andExpectAll(status().isBadRequest(), jsonPath("$.error.code").value(6321));
+        resultActions.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.error.code").value(MealError.INVALID_DATE_FOUND.getCode()));
     }
 
     @Test
@@ -184,6 +188,7 @@ public class GetMealIntegrationTest extends IntegrationTest {
                                 .contentType(MediaType.APPLICATION_JSON));
 
         resultActions.andExpectAll(
-                status().is5xxServerError(), jsonPath("$.error.code").value(5555));
+                status().is5xxServerError(),
+                jsonPath("$.error.code").value(MemberError.HISTORY_NOT_FOUND.getCode()));
     }
 }

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/DeleteMemberIntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/DeleteMemberIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.gaebaljip.exceed.adapter.out.jpa.member.MemberRepository;
 import com.gaebaljip.exceed.common.IntegrationTest;
 import com.gaebaljip.exceed.common.WithMockUser;
+import com.gaebaljip.exceed.common.exception.member.MemberError;
 
 public class DeleteMemberIntegrationTest extends IntegrationTest {
     @Autowired private MemberRepository memberRepository;
@@ -50,6 +51,8 @@ public class DeleteMemberIntegrationTest extends IntegrationTest {
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
 
         // then
-        resultActions.andExpectAll(status().isBadRequest(), jsonPath("$.error.code").value("4448"));
+        resultActions.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.error.code").value(MemberError.INVALID_MEMBER.getCode()));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #534

## 🔑 주요 변경사항

- 쿠키에 SameSite None 적용 (4107b192c7d959f6f324587b26340e270d5ed586)
- 에러코드 수정

## 리뷰어에게
@hwangdaesun 에러코드드가 일관성이 없고 어떠한 기준으로 에러코드를 설정하는지 전혀 파악하지 못하겠습니다. 특히 에러코드는 특정한 오류를 식별하기 위한 코드라고 생각합니다. FE가 해당 코드만 보고도 이게 어떤 에러인지 파악할 수 있거나, code로 후처리 작업을 하는 것으로 알고있습니다. 따라서 에러코드는 절대 중복이 되서는 안된다고 생각하는데 기존에 에러코드는 너무 중복이 많네요.

따라서 에러코드를 다음과 같은 컨벤션으로 수정하였습니다.
- 도메인_상태코드_number
  - 도메인 : 어떠한 도메인에 대한 오류인지
  - 상태코드 : 해당 오류의 상태코드는 몇번인지 (400, 401, 403, 500 etc...)
  - number : 도메인에 대한 오류들을 식별할 수 있는 번호(차례대로 1,2,3,4 ...)
