### PR TITLE
[BE/Docs] Swagger 문서 개선

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/auth/AuthController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/auth/AuthController.java
@@ -18,6 +18,7 @@ import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.EatCeedStaticMessage;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.auth.LoginExceptionDocs;
 import com.gaebaljip.exceed.common.docs.auth.ReissueTokenExceptionDocs;
 import com.gaebaljip.exceed.common.dto.HttpRequestDTO;
@@ -36,7 +37,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[인증]")
+@Tag(name = SwaggerTag.AUTH)
 public class AuthController {
 
     private final AuthUsecase authUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/CreateFoodController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/CreateFoodController.java
@@ -16,6 +16,7 @@ import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
 import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CreateFoodController {
     private final CreateFoodUseCase createFoodUseCase;
 
+    @Operation(summary = "내 음식 추가", description = "내 음식 추가")
     @PostMapping("/food")
     public ApiResponse<CustomBody<Void>> createFood(
             @RequestBody @Valid CreateFoodRequest request, @AuthenticationMemberId Long memberId) {

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/CreateFoodController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/CreateFoodController.java
@@ -14,6 +14,7 @@ import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/v1")
-@Tag(name = "[음식 등록]")
+@Tag(name = SwaggerTag.FOOD)
 public class CreateFoodController {
     private final CreateFoodUseCase createFoodUseCase;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/DeleteFoodController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/DeleteFoodController.java
@@ -31,7 +31,7 @@ public class DeleteFoodController {
 
     private final DeleteFoodUseCase deleteFoodUseCase;
 
-    @Operation(description = "내가 등록한 음식 삭제하기")
+    @Operation(summary = "내가 등록한 음식 삭제", description = "내가 등록한 음식 삭제하기")
     @DeleteMapping("/food/{foodId}")
     @ApiErrorExceptionsExample(DeleteFoodExceptionDocs.class)
     public ApiResponse<ApiResponse.CustomBody<Void>> deleteFood(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/DeleteFoodController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/DeleteFoodController.java
@@ -10,6 +10,7 @@ import com.gaebaljip.exceed.application.port.in.food.DeleteFoodUseCase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.food.DeleteFoodExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
@@ -25,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/v1")
-@Tag(name = "[음식 삭제]")
+@Tag(name = SwaggerTag.FOOD)
 public class DeleteFoodController {
 
     private final DeleteFoodUseCase deleteFoodUseCase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/GetFoodController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/GetFoodController.java
@@ -8,6 +8,7 @@ import com.gaebaljip.exceed.adapter.in.food.response.GetFoodsAutoResponse;
 import com.gaebaljip.exceed.application.port.in.food.GetFoodQuery;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -20,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/v1")
-@Tag(name = "[음식 조회]")
+@Tag(name = SwaggerTag.FOOD)
 public class GetFoodController {
 
     private final GetFoodQuery getFoodQuery;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/GetOwnFoodController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/food/GetOwnFoodController.java
@@ -12,6 +12,7 @@ import com.gaebaljip.exceed.application.port.in.food.GetOwnFoodUseCase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/v1")
-@Tag(name = "[내가 추가한 음식 조회]")
+@Tag(name = SwaggerTag.FOOD)
 public class GetOwnFoodController {
     private final GetOwnFoodUseCase getOwnFoodUseCase;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/EatMealController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/EatMealController.java
@@ -18,6 +18,7 @@ import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.meal.EatMealExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
@@ -31,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[식사 등록]")
+@Tag(name = SwaggerTag.MEAL)
 public class EatMealController {
 
     private final EatMealUsecase eatMealUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/GetMealController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/GetMealController.java
@@ -25,6 +25,7 @@ import com.gaebaljip.exceed.application.service.nutritionist.GetDailyAnalysisSer
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.meal.GetMealExceptionDocs;
 import com.gaebaljip.exceed.common.docs.meal.GetMealFoodExceptionDocs;
 import com.gaebaljip.exceed.common.dto.*;
@@ -42,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[식사 조회]")
+@Tag(name = SwaggerTag.MEAL)
 public class GetMealController {
 
     private final GetMaintainNutritionUsecase getMaintainNutritionUsecase;
@@ -70,7 +71,9 @@ public class GetMealController {
     }
 
     /** 특정 날짜의 식사 정보(단,탄,지 및 칼로지) 조회 */
-    @Operation(summary = "특정 날짜의 식사 정보 조회", description = "특정 날짜의 식사 정보(단,탄,지 및 칼로리)를 조회한다.")
+    @Operation(
+            summary = "특정 날짜의 식사 정보 조회 (켈린더 상세 화면)",
+            description = "특정 날짜의 식사 정보(단,탄,지 및 칼로리)를 조회한다.")
     @GetMapping("/meal/{date}")
     @ApiErrorExceptionsExample(GetMealFoodExceptionDocs.class)
     public ApiResponse<ApiResponse.CustomBody<GetMealFoodResponse>> getMealFood(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/GetMealController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/meal/GetMealController.java
@@ -55,7 +55,7 @@ public class GetMealController {
     private final GetWeightUseCase getWeightUseCase;
 
     /** 오늘 먹은 식사 정보(단,탄,지 및 칼로리) 조회 */
-    @Operation(summary = "오늘 먹은 식사 정보 조회", description = "오늘 먹은 식사 정보(단,탄,지 및 칼로리)를 조회한다.")
+    @Operation(summary = "오늘 먹은 식사 정보 조회 (홈 화면)", description = "오늘 먹은 식사 정보(단,탄,지 및 칼로리)를 조회한다.")
     @GetMapping("/meal")
     @ApiErrorExceptionsExample(GetMealExceptionDocs.class)
     public ApiResponse<ApiResponse.CustomBody<GetMealAndWeightResponse>> getMeal(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/CheckMemberEmailController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/CheckMemberEmailController.java
@@ -13,6 +13,7 @@ import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.UpdateCheckedUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.member.CheckMemberEmailExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
@@ -23,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1")
-@Tag(name = "[이메일 인증]")
+@Tag(name = SwaggerTag.SIGN_UP)
 public class CheckMemberEmailController {
 
     private final CheckCodeUsecase checkCodeUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/DeleteMemberController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/DeleteMemberController.java
@@ -9,6 +9,7 @@ import com.gaebaljip.exceed.application.port.in.member.DeleteMemberUseCase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -19,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[회원탈퇴]")
+@Tag(name = SwaggerTag.MEMBER_MANAGEMENT)
 public class DeleteMemberController {
     private final DeleteMemberUseCase deleteMemberUseCase;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/DeleteMemberController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/DeleteMemberController.java
@@ -11,6 +11,7 @@ import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
 import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class DeleteMemberController {
     private final DeleteMemberUseCase deleteMemberUseCase;
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 한다.")
     @DeleteMapping("/members")
     public ApiResponse<ApiResponse.CustomBody<Void>> deleteMember(
             @Parameter(hidden = true) @AuthenticationMemberId Long memberId) {

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/FindPasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/FindPasswordController.java
@@ -16,6 +16,7 @@ import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.member.FindPassword_updatePasswordExceptionDocs;
 import com.gaebaljip.exceed.common.docs.member.FindPassword_validateEmailExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
@@ -27,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1")
-@Tag(name = "[비밀번호 찾기]")
+@Tag(name = SwaggerTag.ACCOUNT_MANAGEMENT)
 public class FindPasswordController {
 
     private final PasswordValidationUsecase passwordValidationUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/OnBoardingController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/OnBoardingController.java
@@ -13,6 +13,7 @@ import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.member.OnBoardingMemberExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
@@ -26,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[온보딩]")
+@Tag(name = SwaggerTag.ONBOARDING)
 public class OnBoardingController {
 
     private final OnBoardingMemberUsecase onBoardingMemberUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/SignUpMemberController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/SignUpMemberController.java
@@ -10,6 +10,7 @@ import com.gaebaljip.exceed.application.port.in.member.*;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.member.SignUpMemberExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
@@ -22,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[회원가입]")
+@Tag(name = SwaggerTag.SIGN_UP)
 public class SignUpMemberController {
 
     private final ValidateSignUpUsecase validateSignUpUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberController.java
@@ -11,6 +11,7 @@ import com.gaebaljip.exceed.application.port.in.member.UpdateMemberUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.member.UpdateMemberExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
@@ -24,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[회원수정]")
+@Tag(name = SwaggerTag.MEMBER_MANAGEMENT)
 public class UpdateMemberController {
     private final UpdateMemberUsecase updateMemberUsecase;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdateWeightController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdateWeightController.java
@@ -15,6 +15,7 @@ import com.gaebaljip.exceed.application.port.in.member.UpdateWeightUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -25,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[몸무게 수정]")
+@Tag(name = SwaggerTag.MEMBER_MANAGEMENT)
 public class UpdateWeightController {
     private final UpdateWeightUsecase updateWeightUsecase;
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/VerifyEmailCheckedController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/VerifyEmailCheckedController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.gaebaljip.exceed.application.port.in.member.VerifyEmailCheckedUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -19,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[회원가입]")
+@Tag(name = SwaggerTag.SIGN_UP)
 public class VerifyEmailCheckedController {
 
     private final VerifyEmailCheckedUsecase verifyEmailCheckedUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAnalysisController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAnalysisController.java
@@ -16,6 +16,7 @@ import com.gaebaljip.exceed.application.port.in.nutritionist.ValidateSignUpBefor
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
 import com.gaebaljip.exceed.common.docs.nutritionist.GetAnalysisExceptionDocs;
 import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
@@ -31,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequestMapping("/v1")
 @SecurityRequirement(name = "access-token")
-@Tag(name = "[분석 조회]")
+@Tag(name = SwaggerTag.MEAL)
 public class GetAnalysisController {
 
     private final ValidateSignUpBeforeMonthUsecase validateSignUpBeforeMonthUsecase;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAnalysisController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/nutritionist/GetAnalysisController.java
@@ -43,7 +43,7 @@ public class GetAnalysisController {
      * @param memberId
      * @return
      */
-    @Operation(summary = "월별 식사 정보 분석", description = "월별 식사 정보를 분석한다.")
+    @Operation(summary = "월별 식사 정보 분석 (켈린더 분석 화면)", description = "월별 식사 정보를 분석한다.")
     @GetMapping("/achieve/{date}")
     @ApiErrorExceptionsExample(GetAnalysisExceptionDocs.class)
     public ApiResponse<ApiResponse.CustomBody<GetMonthlyAnalysisResponse>> getAnalysis(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/SwaggerTag.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/SwaggerTag.java
@@ -1,0 +1,11 @@
+package com.gaebaljip.exceed.common.docs;
+
+public class SwaggerTag {
+    public static final String AUTH = "[인증]";
+    public static final String ACCOUNT_MANAGEMENT = "[계정 관리]";
+    public static final String SIGN_UP = "[회원 가입]";
+    public static final String ONBOARDING = "[온보딩]";
+    public static final String MEMBER_MANAGEMENT = "[회원 관리]";
+    public static final String MEAL = "[식사]";
+    public static final String FOOD = "[음식]";
+}


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues

## 🔑 주요 변경사항

- Swagger의 Tag 관리하는 SwaggerTag 클래스 생성
- Operation 없는 API에 Operation 추가
- API description 수정(화면 이름 추가하여 AOS 피드백 반영)   

전)
![스크린샷 2024-10-28 오전 1 50 50](https://github.com/user-attachments/assets/43fd8b48-9fb3-4538-a043-c7454323120b)

후)
![스크린샷 2024-10-28 오전 1 50 38](https://github.com/user-attachments/assets/f04dcae2-eed9-413e-beae-8c728eedee1b)

아래와 같이 구조화 하였습니다.

1. 인증
    1. 로그인
    2. 로그아웃
    3. 토큰 재발급
2. 계정 관리
    1. 비밀번호 변경
    2. 비밀번호 찾기
3. 회원가입
    1. 회원가입
    2. 이메일 코드 확인
    3. 회원 가입 후 이메일 인증 여부 확인
4. 온보딩
    1. 온보딩
    2. 온보딩 여부 확인
5. 회원 관리
    1. 회원 수정
    2. 몸무게 수정
    3. 회원 탈퇴
6. 식사 
    1. 식사 등록
    2. 식사 분석 조회 (켈린더 분석)
    3. 오늘 식사 조회 (홈 화면)
    4. 특정 날짜 식사 조회 (켈린더 상세)
7. 음식
    1. 음식 검색
    2. 내 음식 음식 삭제
    3. 내 음식 등록
    4. 내 음식 조회

