### PR TITLE
[BE/Feat] 비밀번호 변경하는 API 개발

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -15,6 +15,8 @@ import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
 import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
 import com.gaebaljip.exceed.common.docs.SwaggerTag;
+import com.gaebaljip.exceed.common.docs.member.UpdatePasswordExceptionDocs;
+import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,6 +33,7 @@ public class UpdatePasswordController {
 
     @Operation(summary = "비밀번호 변경", description = "비밀번호를 변경할 때 사용한다. 해당 API는 로그인 후에 사용하는 API이다.")
     @PatchMapping("/members/password")
+    @ApiErrorExceptionsExample(UpdatePasswordExceptionDocs.class)
     public ApiResponse<CustomBody<Void>> updatePassword(
             @Parameter(hidden = true) @AuthenticationMemberId Long memberId,
             @RequestBody @Valid UpdatePasswordRequest request) {

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -1,0 +1,40 @@
+package com.gaebaljip.exceed.adapter.in.member;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.gaebaljip.exceed.adapter.in.member.request.UpdatePasswordRequest;
+import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
+import com.gaebaljip.exceed.common.ApiResponse;
+import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
+import com.gaebaljip.exceed.common.ApiResponseGenerator;
+import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
+import com.gaebaljip.exceed.common.docs.SwaggerTag;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1")
+@Tag(name = SwaggerTag.ACCOUNT_MANAGEMENT)
+public class UpdatePasswordController {
+
+    private final UpdatePasswordUsecase updatePasswordUsecase;
+
+    @Operation(summary = "비밀번호 변경", description = "비밀번호를 변경할 때 사용한다. 해당 API는 로그인 후에 사용하는 API이다.")
+    @PatchMapping("/members/password")
+    public ApiResponse<CustomBody<Void>> updatePassword(
+            @Parameter(hidden = true) @AuthenticationMemberId Long memberId,
+            @RequestBody @Valid UpdatePasswordRequest request) {
+        updatePasswordUsecase.execute(memberId, request.oldPassword(), request.newPassword());
+        return ApiResponseGenerator.success(HttpStatus.OK);
+    }
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdatePasswordRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdatePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.gaebaljip.exceed.adapter.in.member.request;
+
+import com.gaebaljip.exceed.common.ValidationMessage;
+import com.gaebaljip.exceed.common.annotation.Password;
+
+import lombok.Builder;
+
+public record UpdatePasswordRequest(
+        @Password(message = ValidationMessage.INVALID_PASSWORD) String oldPassword,
+        @Password(message = ValidationMessage.INVALID_PASSWORD) String newPassword) {
+    @Builder
+    public UpdatePasswordRequest {}
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/UpdatePasswordUsecase.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/port/in/member/UpdatePasswordUsecase.java
@@ -5,4 +5,6 @@ import com.gaebaljip.exceed.common.annotation.UseCase;
 @UseCase
 public interface UpdatePasswordUsecase {
     void execute(String email, String password);
+
+    void execute(Long memberId, String oldPassword, String newPassword);
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/UpdatePasswordService.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/service/member/UpdatePasswordService.java
@@ -2,15 +2,19 @@ package com.gaebaljip.exceed.application.service.member;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
 import com.gaebaljip.exceed.application.port.out.member.MemberPort;
+import com.gaebaljip.exceed.common.exception.auth.PasswordMismatchException;
+import com.gaebaljip.exceed.common.exception.member.SamePasswordException;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UpdatePasswordService implements UpdatePasswordUsecase {
 
     private final MemberPort memberPort;
@@ -20,5 +24,26 @@ public class UpdatePasswordService implements UpdatePasswordUsecase {
     public void execute(String email, String password) {
         MemberEntity member = memberPort.findMemberByEmail(email);
         member.updatePassword(bCryptPasswordEncoder.encode(password));
+    }
+
+    @Override
+    public void execute(Long memberId, String oldPassword, String newPassword) {
+        MemberEntity member = memberPort.query(memberId);
+        String originPassword = member.getPassword();
+        validateOldPasswordMatch(oldPassword, originPassword);
+        validatePasswordIsSame(oldPassword, newPassword);
+        member.updatePassword(bCryptPasswordEncoder.encode(newPassword));
+    }
+
+    private void validateOldPasswordMatch(String oldPassword, String originPassword) {
+        if (!bCryptPasswordEncoder.matches(oldPassword, originPassword)) {
+            throw PasswordMismatchException.EXECPTION;
+        }
+    }
+
+    public void validatePasswordIsSame(String oldPassword, String newPassword) {
+        if (oldPassword.equals(newPassword)) {
+            throw SamePasswordException.EXECPTION;
+        }
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePasswordExceptionDocs.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/docs/member/UpdatePasswordExceptionDocs.java
@@ -1,0 +1,18 @@
+package com.gaebaljip.exceed.common.docs.member;
+
+import com.gaebaljip.exceed.common.exception.EatCeedException;
+import com.gaebaljip.exceed.common.exception.auth.PasswordMismatchException;
+import com.gaebaljip.exceed.common.exception.member.SamePasswordException;
+import com.gaebaljip.exceed.common.swagger.ExceptionDoc;
+import com.gaebaljip.exceed.common.swagger.ExplainError;
+import com.gaebaljip.exceed.common.swagger.SwaggerExampleExceptions;
+
+@ExceptionDoc
+public class UpdatePasswordExceptionDocs implements SwaggerExampleExceptions {
+
+    @ExplainError("기존 비밀번호가 잘못된 비밀번호일 경우")
+    public EatCeedException 기존_비밀번호가_잘못된_비밀번호일_경우 = PasswordMismatchException.EXECPTION;
+
+    @ExplainError("바꾸려는 비밀번호가 기존 비밀번호와 같을 경우")
+    public EatCeedException 바꾸려는_비밀번호가_기존_비밀번호와_같을_경우 = SamePasswordException.EXECPTION;
+}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/MemberError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/MemberError.java
@@ -22,7 +22,8 @@ public enum MemberError implements BaseError {
     INVALID_WEIGHT(400, "MEMBER_400_7", "몸무게가 음수일 수 없습니다."),
     MAIL_SEND_FAIL(400, "MEMBER_400_8", "메일 전송에 실패하였습니다."),
     INVALID_MEMBER(400, "MEMBER_400_9", "존재하지 않는 회원입니다."),
-    HISTORY_NOT_FOUND(500, "MEMBER_500_1", "첫 온보딩하기 전입니다.");
+    HISTORY_NOT_FOUND(500, "MEMBER_500_1", "첫 온보딩하기 전입니다."),
+    SAME_PASSWORD(400, "MEMBER_400_10", "바꾸려는 비밀번호가 기존 비밀번호와 같아서 변경할 수 없습니다.");
     private final Integer status;
     private final String code;
     private final String reason;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/SamePasswordException.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/member/SamePasswordException.java
@@ -1,0 +1,14 @@
+package com.gaebaljip.exceed.common.exception.member;
+
+import com.gaebaljip.exceed.common.exception.EatCeedException;
+
+import lombok.Getter;
+
+@Getter
+public class SamePasswordException extends EatCeedException {
+    public static EatCeedException EXECPTION = new SamePasswordException();
+
+    public SamePasswordException() {
+        super(MemberError.SAME_PASSWORD);
+    }
+}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/UpdatePasswordIntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/UpdatePasswordIntegrationTest.java
@@ -2,6 +2,8 @@ package com.gaebaljip.exceed.integration.member;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,8 @@ import com.gaebaljip.exceed.adapter.out.jpa.member.MemberRepository;
 import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 import com.gaebaljip.exceed.common.IntegrationTest;
 import com.gaebaljip.exceed.common.WithMockUser;
+import com.gaebaljip.exceed.common.exception.auth.AuthError;
+import com.gaebaljip.exceed.common.exception.member.MemberError;
 
 public class UpdatePasswordIntegrationTest extends IntegrationTest {
 
@@ -49,5 +53,67 @@ public class UpdatePasswordIntegrationTest extends IntegrationTest {
         // then
 
         assertTrue(bCryptPasswordEncoder.matches(newPassword, memberEntity.getPassword()));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 바꾸려는 비밀번호와 기존 비밀번호가 같을 경우")
+    @WithMockUser
+    void when_updatePassword_expected_fail_1() throws Exception {
+        // given
+
+        Long memberId = 1L;
+        String oldPassword = "Abc@123";
+        String newPassword = "Abc@123";
+        UpdatePasswordRequest updatePasswordRequest =
+                UpdatePasswordRequest.builder()
+                        .oldPassword(oldPassword)
+                        .newPassword(newPassword)
+                        .build();
+
+        // when
+
+        ResultActions resultActions =
+                mockMvc.perform(
+                        patch("/v1/members/password")
+                                .content(om.writeValueAsString(updatePasswordRequest))
+                                .contentType(MediaType.APPLICATION_JSON));
+        MemberEntity memberEntity = memberRepository.findById(1L).get();
+
+        // then
+
+        resultActions.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.error.code").value(MemberError.SAME_PASSWORD.getCode()));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 본인 확인용으로 작성한 비밀번호가 실제 비밀번호와 다를 경우")
+    @WithMockUser
+    void when_updatePassword_expected_fail_2() throws Exception {
+        // given
+
+        Long memberId = 1L;
+        String InvalidOldPassword = "Abc@000";
+        String newPassword = "Abcd@1234";
+        UpdatePasswordRequest updatePasswordRequest =
+                UpdatePasswordRequest.builder()
+                        .oldPassword(InvalidOldPassword)
+                        .newPassword(newPassword)
+                        .build();
+
+        // when
+
+        ResultActions resultActions =
+                mockMvc.perform(
+                        patch("/v1/members/password")
+                                .content(om.writeValueAsString(updatePasswordRequest))
+                                .contentType(MediaType.APPLICATION_JSON));
+        MemberEntity memberEntity = memberRepository.findById(1L).get();
+
+        // then
+
+        resultActions.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.error.code").value(AuthError.PASSWORD_MISMATCH.getCode()));
     }
 }

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/UpdatePasswordIntegrationTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/integration/member/UpdatePasswordIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.gaebaljip.exceed.integration.member;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.gaebaljip.exceed.adapter.in.member.request.UpdatePasswordRequest;
+import com.gaebaljip.exceed.adapter.out.jpa.member.MemberRepository;
+import com.gaebaljip.exceed.application.domain.member.MemberEntity;
+import com.gaebaljip.exceed.common.IntegrationTest;
+import com.gaebaljip.exceed.common.WithMockUser;
+
+public class UpdatePasswordIntegrationTest extends IntegrationTest {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    @WithMockUser(memberId = 1L)
+    void when_updatePassword_expected_success() throws Exception {
+
+        // given
+
+        Long memberId = 1L;
+        String oldPassword = "Abc@123";
+        String newPassword = "Abcd@1234";
+        UpdatePasswordRequest updatePasswordRequest =
+                UpdatePasswordRequest.builder()
+                        .oldPassword(oldPassword)
+                        .newPassword(newPassword)
+                        .build();
+
+        // when
+
+        ResultActions resultActions =
+                mockMvc.perform(
+                        patch("/v1/members/password")
+                                .content(om.writeValueAsString(updatePasswordRequest))
+                                .contentType(MediaType.APPLICATION_JSON));
+        MemberEntity memberEntity = memberRepository.findById(1L).get();
+
+        // then
+
+        assertTrue(bCryptPasswordEncoder.matches(newPassword, memberEntity.getPassword()));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/548

## 🔑 주요 변경사항

- 비밀번호 변경 API 개발
     - "기존 비밀번호가 잘못된 비밀번호일 경우"와" 바꾸려는 비밀번호가 기존 비밀번호와 같을 경우" 예외 처리 수행
- 해당 API Swagger 반영
- 비밀번호 변경 API 통합 테스트 수행
     - 비밀번호 변경 성공 시 통합테스트 수행
     - "기존 비밀번호가 잘못된 비밀번호일 경우"와" 바꾸려는 비밀번호가 기존 비밀번호와 같을 경우" 예외일 경우 실패 통합 테스트 수행