### PR TITLE
[BE/FIX] 온보딩과 회원 수정 시 'etc' 필드 검증 기준 불일치 해결

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdateMemberRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdateMemberRequest.java
@@ -1,7 +1,6 @@
 package com.gaebaljip.exceed.adapter.in.member.request;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import com.gaebaljip.exceed.application.domain.member.Activity;
@@ -21,4 +20,4 @@ public record UpdateMemberRequest(
                 @Min(value = 0, message = "나이는 " + ValidationMessage.MIN_0)
                 Integer age,
         @Enum(enumClass = Activity.class) String activity,
-        @NotBlank(message = "기타사항을 " + ValidationMessage.NOT_BLANK) String etc) {}
+        String etc) {}

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberControllerTest.java
@@ -205,31 +205,4 @@ public class UpdateMemberControllerTest extends ControllerTest {
                 status().isBadRequest(),
                 jsonPath("$.error.reason").value(activity + "는 올바르지 않은 값입니다."));
     }
-
-    @Test
-    @DisplayName("회원 수정 실패 - 기타사항을 입력하지 않은 경우")
-    @WithMockUser
-    void when_updateMember_etc_null_expected_exception() throws Exception {
-        // given
-        UpdateMemberRequest updateMemberRequest =
-                UpdateMemberRequest.builder()
-                        .height(180.3)
-                        .activity("VERY_ACTIVE")
-                        .age(40)
-                        .gender("MALE")
-                        .etc(null)
-                        .build();
-
-        // when
-        ResultActions resultActions =
-                mockMvc.perform(
-                        put("/v1/members")
-                                .content(om.writeValueAsString(updateMemberRequest))
-                                .contentType(MediaType.APPLICATION_JSON));
-
-        // then
-        resultActions.andExpectAll(
-                status().isBadRequest(),
-                jsonPath("$.error.reason").value("기타사항을 " + ValidationMessage.NOT_BLANK));
-    }
 }

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/adapter/in/member/UpdateMemberControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -16,10 +18,11 @@ import com.gaebaljip.exceed.common.WithMockUser;
 
 public class UpdateMemberControllerTest extends ControllerTest {
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"", "  ", "매운 거 못 먹음"})
     @DisplayName("회원 수정 성공")
     @WithMockUser
-    void when_updateMember_expected_success() throws Exception {
+    void when_updateMember_expected_success(String etc) throws Exception {
         // given
         UpdateMemberRequest updateMemberRequest =
                 UpdateMemberRequest.builder()
@@ -27,7 +30,7 @@ public class UpdateMemberControllerTest extends ControllerTest {
                         .activity("VERY_ACTIVE")
                         .age(40)
                         .gender("MALE")
-                        .etc("회원 수정")
+                        .etc(etc)
                         .build();
         // when
         ResultActions resultActions =


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/550

## 🔑 주요 변경사항

- 온보딩시에는 null, "", " "값이 허용되는 반면, 회원 수정 시에는 @notblank로 검증하고 있었어, 이를 온보딩 API에 맞게 일치시켰습니다.
- 기존 회원 수정 통합 테스트 - 기타사항 : 해당 테스트를 제거하였습니다.
- 기존 회원 수정 컨트롤러 테스트에 etc 파라미터를 추가하여 테스트를 수정하였습니다. 
