### PR TITLE
[BE/FIX] Swagger 403 응답 해결

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdatePasswordController.java
@@ -20,12 +20,14 @@ import com.gaebaljip.exceed.common.swagger.ApiErrorExceptionsExample;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1")
+@SecurityRequirement(name = "access-token")
 @Tag(name = SwaggerTag.ACCOUNT_MANAGEMENT)
 public class UpdatePasswordController {
 

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.gaebaljip.exceed.common.security.config;
 
-import java.util.Arrays;
-
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
@@ -11,10 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.gaebaljip.exceed.common.security.domain.JwtManager;
 import com.gaebaljip.exceed.common.security.domain.JwtResolver;
@@ -50,9 +45,6 @@ public class SecurityConfig {
                 .disable()
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .cors()
-                .configurationSource(corsConfigurationSource())
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(jwtAuthenticationPoint)
@@ -92,24 +84,6 @@ public class SecurityConfig {
                 new JwtAuthenticationFilter(jwtManager, jwtResolver, memberDetailService),
                 UsernamePasswordAuthenticationFilter.class);
         return http.build();
-    }
-
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
-        configuration.setAllowedMethods(
-                Arrays.asList("HEAD", "POST", "GET", "DELETE", "PUT", "PATCH", "OPTIONS"));
-        configuration.setAllowedHeaders(
-                Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
-        configuration.setExposedHeaders(Arrays.asList("Authorization"));
-        configuration.setMaxAge(3600L);
-        configuration.setAllowCredentials(true);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 
     @Bean


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/553

## 🔑 주요 변경사항

처음에는 CORS 설정에 허용하는 origin에 해당 도메인을 추가하려고 했으나 이상하여 CORS를 다시 공부하였습니다.😅
(위 방식으로 해결이 되긴 됩니다.)

CORS가 나온 배경을 살펴보면, 본래는 동일한 출처에서만 리소스를 공유할 수 있는데 현실적으로 그게 어려워서 예외적으로 출처를 허용해주는 것이 CORS입니다.


<img width="500" alt="스크린샷 2024-11-04 오후 10 20 06" src="https://github.com/user-attachments/assets/988d5774-32fa-462b-a94d-cbd612051ed8">

위 과정은 Preflight Request 방식인데 웹에서는 서버에서 응답이 온 Aceess-Control-Allow-Origin 헤더를 보고 이를 자신의 origin가 비교하여 속하지 않으면 CORS 에러를 던집니다.
여기서 중요한 것은 웹 브라우저가 CORS 에러를 던진다는 것입니다.
그리고, 앱에서는 따로 CORS 에러를 체크하지 않습니다.

현재 EATceed는 웹 브라우저에서 통신하는 origin이 Swagger 밖에 없으므로(동일 출처) cors 설정을 할 필요가 없어 제거하였습니다.

### 결과

수동 배포하여 아래 사항 확인하였습니다.

- Swagger 정상 작동 확인
- AOS 정상 작동 확인(POST, GET 요청)

