### PR TITLE
[BE/FEAT] 예외 응답시 errorCode가 null로 반환되는 경우 핸들링

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/auth/request/LoginRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/auth/request/LoginRequest.java
@@ -1,6 +1,7 @@
 package com.gaebaljip.exceed.adapter.in.auth.request;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.annotation.Password;
@@ -8,7 +9,9 @@ import com.gaebaljip.exceed.common.annotation.Password;
 import lombok.Builder;
 
 public record LoginRequest(
-        @Email(message = ValidationMessage.INVALID_EMAIL) String email,
+        @Email(message = ValidationMessage.INVALID_EMAIL)
+                @NotEmpty(message = "이메일을 " + ValidationMessage.NOT_EMPTY)
+                String email,
         @Password(message = ValidationMessage.INVALID_PASSWORD) String password) {
     @Builder
     public LoginRequest {}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdateWeightController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/UpdateWeightController.java
@@ -1,6 +1,7 @@
 package com.gaebaljip.exceed.adapter.in.member;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -18,6 +19,7 @@ import com.gaebaljip.exceed.common.annotation.AuthenticationMemberId;
 import com.gaebaljip.exceed.common.docs.SwaggerTag;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -34,8 +36,8 @@ public class UpdateWeightController {
     @PatchMapping("/members/weight")
     public ApiResponse<UpdateWeightResponse> updateWeight(
             HttpServletRequest servletRequest,
-            @RequestBody UpdateWeightRequest request,
-            @AuthenticationMemberId Long memberId) {
+            @RequestBody @Valid UpdateWeightRequest request,
+            @Parameter(hidden = true) @AuthenticationMemberId Long memberId) {
         UpdateWeightResponse response =
                 updateWeightUsecase.execute(
                         UpdateWeightCommand.of(

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/CheckMemberRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/CheckMemberRequest.java
@@ -1,14 +1,18 @@
 package com.gaebaljip.exceed.adapter.in.member.request;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 import com.gaebaljip.exceed.common.ValidationMessage;
 
 import lombok.Builder;
 
 public record CheckMemberRequest(
-        @NotNull(message = "이메일을 " + ValidationMessage.NOT_NULL) String email,
-        @NotNull(message = "코드를 " + ValidationMessage.NOT_NULL) String code) {
+        @Email(message = ValidationMessage.INVALID_EMAIL)
+                @NotEmpty(message = "이메일을 " + ValidationMessage.NOT_EMPTY)
+                String email,
+        @NotBlank(message = "코드를 " + ValidationMessage.NOT_NULL) String code) {
     @Builder
     public CheckMemberRequest {}
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/FindPasswordRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/FindPasswordRequest.java
@@ -2,6 +2,7 @@ package com.gaebaljip.exceed.adapter.in.member.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.annotation.Password;
@@ -9,9 +10,11 @@ import com.gaebaljip.exceed.common.annotation.Password;
 import lombok.Builder;
 
 public record FindPasswordRequest(
-        @Email(message = ValidationMessage.INVALID_EMAIL) String email,
+        @Email(message = ValidationMessage.INVALID_EMAIL)
+                @NotEmpty(message = "이메일을 " + ValidationMessage.NOT_EMPTY)
+                String email,
         @Password(message = ValidationMessage.INVALID_PASSWORD) String newPassword,
-        @NotBlank(message = "인증 코드를  " + ValidationMessage.NOT_BLANK) String code) {
+        @NotBlank(message = "인증 코드를 " + ValidationMessage.NOT_BLANK) String code) {
 
     @Builder
     public FindPasswordRequest {}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/SendEmailRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/SendEmailRequest.java
@@ -1,7 +1,11 @@
 package com.gaebaljip.exceed.adapter.in.member.request;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 
 import com.gaebaljip.exceed.common.ValidationMessage;
 
-public record SendEmailRequest(@Email(message = ValidationMessage.INVALID_EMAIL) String email) {}
+public record SendEmailRequest(
+        @Email(message = ValidationMessage.INVALID_EMAIL)
+                @NotEmpty(message = "이메일을 " + ValidationMessage.NOT_EMPTY)
+                String email) {}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/SignUpMemberRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/SignUpMemberRequest.java
@@ -1,6 +1,7 @@
 package com.gaebaljip.exceed.adapter.in.member.request;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 
 import com.gaebaljip.exceed.common.ValidationMessage;
 import com.gaebaljip.exceed.common.annotation.Password;
@@ -8,7 +9,9 @@ import com.gaebaljip.exceed.common.annotation.Password;
 import lombok.Builder;
 
 public record SignUpMemberRequest(
-        @Email(message = ValidationMessage.INVALID_EMAIL) String email,
+        @Email(message = ValidationMessage.INVALID_EMAIL)
+                @NotEmpty(message = "이메일을 " + ValidationMessage.NOT_EMPTY)
+                String email,
         @Password(message = ValidationMessage.INVALID_PASSWORD) String password) {
     @Builder
     public SignUpMemberRequest {}

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdateWeightRequest.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/adapter/in/member/request/UpdateWeightRequest.java
@@ -1,8 +1,19 @@
 package com.gaebaljip.exceed.adapter.in.member.request;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import com.gaebaljip.exceed.common.ValidationMessage;
+
 import lombok.Builder;
 
-public record UpdateWeightRequest(Double weight, Double targetWeight) {
+public record UpdateWeightRequest(
+        @NotNull(message = "몸무게를 " + ValidationMessage.NOT_NULL)
+                @Min(value = 0, message = "몸무게는 " + ValidationMessage.MIN_0)
+                Double weight,
+        @NotNull(message = "목표 몸무게를 " + ValidationMessage.NOT_NULL)
+                @Min(value = 0, message = "목표 몸무게는 " + ValidationMessage.MIN_0)
+                Double targetWeight) {
     @Builder
     public UpdateWeightRequest {}
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/MealFoodEntity.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/application/domain/meal/MealFoodEntity.java
@@ -84,6 +84,7 @@ public class MealFoodEntity extends BaseEntity {
         return unit.getStrategy()
                 .measure(this.foodEntity.getFat(), unit, this.foodEntity.getServingSize());
     }
+
     @Override
     public String toString() {
         return "MealFoodEntity{"
@@ -95,5 +96,4 @@ public class MealFoodEntity extends BaseEntity {
                 + unit.getG()
                 + '}';
     }
-
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/ValidationMessage.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/ValidationMessage.java
@@ -7,9 +7,10 @@ public class ValidationMessage {
     public static final String INVALID_PASSWORD =
             "비밀번호 형식이 올바르지 않습니다. 비밀번호는 최소 6글자 이상이며, 영어와 특수문자를 포함해야 합니다.";
 
-    public static final String NOT_NULL = "입력해 주세요";
-    public static final String NOT_BLANK = "입력해 주세요";
-    public static final String MIN_0 = "0이상 입력해 주세요";
+    public static final String NOT_NULL = "입력해 주세요.";
+    public static final String NOT_EMPTY = "입력해 주세요.";
+    public static final String NOT_BLANK = "입력해 주세요.";
+    public static final String MIN_0 = "0이상 입력해 주세요.";
 
     public static final String ENUM_SUFFIX = "는 올바르지 않은 값입니다.";
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/annotation/PasswordValidator.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/annotation/PasswordValidator.java
@@ -4,11 +4,10 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
+    public static String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\W).{6,}$";
+
     @Override
-    public boolean isValid(String value, ConstraintValidatorContext context) {
-        if (value == null) {
-            return false;
-        }
-        return value.matches("^(?=.*[A-Za-z])(?=.*\\W).{6,}$");
+    public boolean isValid(String password, ConstraintValidatorContext context) {
+        return password.matches(PASSWORD_REGEX);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalError.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalError.java
@@ -15,6 +15,9 @@ public enum GlobalError implements BaseError {
     ENCRYPTION_FAIL(500, "ENCRYPTION_500_1", "암호화에 실패하였습니다."),
     DECRYPTION_FAIL(500, "ENCRYPTION_500_2", "복호화에 실패하였습니다."),
     EXTENTION_NOT_ALLOWED(400, "GLOBAL_400_1", "이미지의 확장자는 jpg, jpeg, png만 가능합니다."),
+
+    // AOS에서 Default Message를 사용하도록 하는 에러 코드
+    INVALID_FIELD(400, "GLOBAL_400_999", "응답시 반환되는 error.reason을 사용해주세요.");
     ;
 
     private final Integer status;

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalExceptionHandler.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/common/exception/GlobalExceptionHandler.java
@@ -127,6 +127,7 @@ public class GlobalExceptionHandler {
     protected ApiResponse<?> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException e) {
         return ApiResponseGenerator.fail(
+                GlobalError.INVALID_FIELD.getCode(),
                 e.getBindingResult().getFieldErrors().get(0).getDefaultMessage(),
                 HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/558

## 🔑 주요 변경사항

- @Email 에서 "  " 는 인식 가능하나 ""와 null은 인식 불가해 @NotEmpty 추가
- GlobalError에 INVALID_FIELD 추가하여 예외 처리 응답시 error.code에 null이 나올 경우 GLOBAL_400_999가 반환되도록 수정
- 기타 Request Validation 안 된 것들 추가

노션 - 에러 코드 정리 페이지에 정리 추가(슬랙 회의록에 링크 존재)

@LJH098 음식 관련 API는 음식 API 오류 수정때 부탁드리겠습니다.😀
