### PR TITLE
[BE/FEAT] 이메일 인증 방식 변경

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/adapter/in/member/CheckMemberEmailController.java
+++ b/src/main/java/com/gaebaljip/exceed/adapter/in/member/CheckMemberEmailController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 
 import com.gaebaljip.exceed.adapter.in.member.request.CheckMemberRequest;
 import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
-import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.UpdateCheckedUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponseGenerator;
@@ -28,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 public class CheckMemberEmailController {
 
     private final CheckCodeUsecase checkCodeUsecase;
-    private final GetCodeUsecase getCodeUsecase;
     private final UpdateCheckedUsecase updateCheckedUsecase;
 
     @Value("${exceed.deepLink.signUp}")
@@ -46,11 +44,8 @@ public class CheckMemberEmailController {
 
     @Operation(summary = "링크 클릭시 리다이렉트", description = "AOS는 몰라도 되는 API")
     @GetMapping("/signUp-redirect")
-    public void redirect(@RequestParam String email, HttpServletResponse response) {
-        StringBuilder sb = new StringBuilder();
-        String code = getCodeUsecase.execute(email);
-        String redirectUrl = sb.append(deepLink).append("?code=").append(code).toString();
-        response.setHeader("Location", redirectUrl);
+    public void redirect(HttpServletResponse response) {
+        response.setHeader("Location", deepLink);
         response.setStatus(302);
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/adapter/in/member/FindPasswordController.java
+++ b/src/main/java/com/gaebaljip/exceed/adapter/in/member/FindPasswordController.java
@@ -11,7 +11,7 @@ import com.gaebaljip.exceed.adapter.in.member.request.FindPasswordRequest;
 import com.gaebaljip.exceed.adapter.in.member.request.SendEmailRequest;
 import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
-import com.gaebaljip.exceed.application.port.in.member.PasswordValidationUsecase;
+import com.gaebaljip.exceed.application.port.in.member.CheckSignUpMemberUsecase;
 import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
 import com.gaebaljip.exceed.common.ApiResponse.CustomBody;
@@ -31,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = SwaggerTag.ACCOUNT_MANAGEMENT)
 public class FindPasswordController {
 
-    private final PasswordValidationUsecase passwordValidationUsecase;
+    private final CheckSignUpMemberUsecase checkSignUpMemberUsecase;
     private final GetCodeUsecase getCodeUsecase;
 
     @Value("${exceed.deepLink.updatePassword}")
@@ -45,9 +45,9 @@ public class FindPasswordController {
             description = "비밀번호 찾기 전, 이메일 검증 및 이메일을 재전송한다.")
     @PostMapping("/email")
     @ApiErrorExceptionsExample(FindPassword_validateEmailExceptionDocs.class)
-    public ApiResponse<CustomBody<Void>> validateEmail(
+    public ApiResponse<CustomBody<Void>> checkSignUpMember(
             @RequestBody @Valid SendEmailRequest request) {
-        passwordValidationUsecase.execute(request.email());
+        checkSignUpMemberUsecase.execute(request.email());
         return ApiResponseGenerator.success(HttpStatus.OK);
     }
 

--- a/src/main/java/com/gaebaljip/exceed/adapter/in/member/FindPasswordController.java
+++ b/src/main/java/com/gaebaljip/exceed/adapter/in/member/FindPasswordController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 import com.gaebaljip.exceed.adapter.in.member.request.FindPasswordRequest;
 import com.gaebaljip.exceed.adapter.in.member.request.SendEmailRequest;
 import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
-import com.gaebaljip.exceed.application.port.in.member.GetCodeUsecase;
 import com.gaebaljip.exceed.application.port.in.member.CheckSignUpMemberUsecase;
 import com.gaebaljip.exceed.application.port.in.member.UpdatePasswordUsecase;
 import com.gaebaljip.exceed.common.ApiResponse;
@@ -32,7 +31,6 @@ import lombok.RequiredArgsConstructor;
 public class FindPasswordController {
 
     private final CheckSignUpMemberUsecase checkSignUpMemberUsecase;
-    private final GetCodeUsecase getCodeUsecase;
 
     @Value("${exceed.deepLink.updatePassword}")
     private String deepLink;
@@ -53,11 +51,8 @@ public class FindPasswordController {
 
     @Operation(summary = "링크 클릭시 리다이렉트", description = "AOS는 몰라도 되는 API")
     @GetMapping("/findPassword-redirect")
-    public void redirect(@RequestParam String email, HttpServletResponse response) {
-        StringBuilder sb = new StringBuilder();
-        String code = getCodeUsecase.execute(email);
-        String redirectUrl = sb.append(deepLink).append("?code=").append(code).toString();
-        response.setHeader("Location", redirectUrl);
+    public void redirect(HttpServletResponse response) {
+        response.setHeader("Location", deepLink);
         response.setStatus(302);
     }
 

--- a/src/main/java/com/gaebaljip/exceed/application/domain/member/Code.java
+++ b/src/main/java/com/gaebaljip/exceed/application/domain/member/Code.java
@@ -1,9 +1,12 @@
 package com.gaebaljip.exceed.application.domain.member;
 
-import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class Code {
-    public static String create() {
-        return UUID.randomUUID().toString();
+    public static final int START = 100000;
+    public static final int END = 1000000;
+
+    public int createRandom() {
+        return ThreadLocalRandom.current().nextInt(START, END);
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/application/port/in/member/CheckSignUpMemberUsecase.java
+++ b/src/main/java/com/gaebaljip/exceed/application/port/in/member/CheckSignUpMemberUsecase.java
@@ -3,6 +3,6 @@ package com.gaebaljip.exceed.application.port.in.member;
 import com.gaebaljip.exceed.common.annotation.UseCase;
 
 @UseCase
-public interface PasswordValidationUsecase {
+public interface CheckSignUpMemberUsecase {
     void execute(String email);
 }

--- a/src/main/java/com/gaebaljip/exceed/application/service/member/CheckCodeService.java
+++ b/src/main/java/com/gaebaljip/exceed/application/service/member/CheckCodeService.java
@@ -5,8 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.gaebaljip.exceed.application.port.in.member.CheckCodeUsecase;
 import com.gaebaljip.exceed.application.port.out.member.CodePort;
-import com.gaebaljip.exceed.common.Encryption;
-import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.exception.member.ExpiredCodeException;
 
 import lombok.RequiredArgsConstructor;
@@ -15,15 +13,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CheckCodeService implements CheckCodeUsecase {
 
-    private final Encryption encryption;
     private final CodePort codePort;
 
     @Override
     @Transactional
-    @Timer
-    public void execute(String email, String encrypt) {
-        String code = codePort.query(email).orElseThrow(() -> ExpiredCodeException.EXECPTION);
-        String decrypt = encryption.decrypt(encrypt);
-        encryption.match(decrypt, code);
+    public void execute(String email, String rawCode) {
+        String validCode = codePort.query(email).orElseThrow(() -> ExpiredCodeException.EXECPTION);
+        if (!validCode.equals(rawCode)) {
+            throw ExpiredCodeException.EXECPTION;
+        }
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/application/service/member/CheckSignUpMemberService.java
+++ b/src/main/java/com/gaebaljip/exceed/application/service/member/CheckSignUpMemberService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.gaebaljip.exceed.application.domain.member.MemberEntity;
-import com.gaebaljip.exceed.application.port.in.member.PasswordValidationUsecase;
+import com.gaebaljip.exceed.application.port.in.member.CheckSignUpMemberUsecase;
 import com.gaebaljip.exceed.application.port.out.member.MemberPort;
 import com.gaebaljip.exceed.common.annotation.EventPublisherStatus;
 import com.gaebaljip.exceed.common.event.Events;
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class PasswordValidationService implements PasswordValidationUsecase {
+public class CheckSignUpMemberService implements CheckSignUpMemberUsecase {
 
     private final MemberPort memberPort;
 

--- a/src/main/java/com/gaebaljip/exceed/application/service/member/CreateMemberService.java
+++ b/src/main/java/com/gaebaljip/exceed/application/service/member/CreateMemberService.java
@@ -9,7 +9,6 @@ import com.gaebaljip.exceed.application.domain.member.MemberEntity;
 import com.gaebaljip.exceed.application.port.in.member.CreateMemberUsecase;
 import com.gaebaljip.exceed.application.port.out.member.MemberPort;
 import com.gaebaljip.exceed.common.annotation.EventPublisherStatus;
-import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.event.Events;
 import com.gaebaljip.exceed.common.event.SignUpMemberEvent;
 
@@ -23,7 +22,6 @@ public class CreateMemberService implements CreateMemberUsecase {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Override
-    @Timer
     @Transactional
     @EventPublisherStatus
     public void execute(SignUpMemberRequest signUpMemberRequest) {

--- a/src/main/java/com/gaebaljip/exceed/common/Encryption.java
+++ b/src/main/java/com/gaebaljip/exceed/common/Encryption.java
@@ -5,7 +5,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 import javax.crypto.Cipher;
@@ -16,9 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.gaebaljip.exceed.common.annotation.Timer;
-import com.gaebaljip.exceed.common.exception.DecryptionErrorException;
 import com.gaebaljip.exceed.common.exception.EncryptionErrorException;
-import com.gaebaljip.exceed.common.exception.member.ExpiredCodeException;
 
 @Component
 public class Encryption {
@@ -45,25 +42,6 @@ public class Encryption {
         } catch (Exception e) {
             throw EncryptionErrorException.EXECPTION;
         }
-    }
-
-    @Timer
-    public String decrypt(final String encryptedValue) {
-        try {
-            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
-            byte[] encryptedBytes = Base64.getUrlDecoder().decode(encryptedValue);
-            byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
-            return new String(decryptedBytes, StandardCharsets.UTF_8); // 바이트 배열을 String으로 변환
-        } catch (Exception e) {
-            throw DecryptionErrorException.EXECPTION;
-        }
-    }
-
-    public Boolean match(final String decrypt, final String value) {
-        if (!Objects.equals(decrypt, value)) {
-            throw ExpiredCodeException.EXECPTION;
-        }
-        return true;
     }
 
     @PostConstruct

--- a/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
+++ b/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
@@ -8,6 +8,7 @@ public class MailTemplate {
     public static final String FIND_PASSWORD_TITLE = "Eatceed 비밀번호 찾기 메일";
     public static final String SIGN_UP_MAIL_CONTEXT = "signupLink";
     public static final String FIND_PASSWORD_MAIL_CONTEXT = "findPasswordLink";
+    public static final String SIGN_UP_CODE = "code";
     public static final String SIGN_UP_EMAIL = "email";
     public static final String FIND_PASSWORD_EMAIL = "email";
     public static final String REPLY_TO_SIGN_UP_MAIL_URL = "/v1/signUp-redirect";

--- a/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
+++ b/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
@@ -13,4 +13,5 @@ public class MailTemplate {
     public static final String FIND_PASSWORD_EMAIL = "email";
     public static final String REPLY_TO_SIGN_UP_MAIL_URL = "/v1/signUp-redirect";
     public static final String REPLY_TO_FIND_PASSWORD_MAIL_URL = "/v1/findPassword-redirect";
+    public static final String FIND_PASSWORD_CODE = "code";
 }

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/InCompleteSignUpMemberEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/InCompleteSignUpMemberEventListener.java
@@ -31,11 +31,12 @@ public class InCompleteSignUpMemberEventListener {
     @EventListener(classes = IncompleteSignUpEvent.class)
     @Async
     public void handle(IncompleteSignUpEvent event) {
-        codePort.saveWithExpiration(event.getEmail(), Code.create(), expiredTime);
+        int randomCode = createRandom();
+        codePort.saveWithExpiration(event.getEmail(), String.valueOf(randomCode), expiredTime);
         Context context = new Context();
         context.setVariable(
                 MailTemplate.SIGN_UP_MAIL_CONTEXT, URL + MailTemplate.REPLY_TO_SIGN_UP_MAIL_URL);
-        context.setVariable(MailTemplate.SIGN_UP_EMAIL, "?email=" + event.getEmail());
+        context.setVariable(MailTemplate.SIGN_UP_CODE, randomCode);
         try {
             emailPort.sendEmail(
                     event.getEmail(),
@@ -46,5 +47,11 @@ public class InCompleteSignUpMemberEventListener {
             log.info("msg : {}", "메일 전송에 실패했습니다.");
             codePort.delete(event.getEmail());
         }
+    }
+
+    private int createRandom() {
+        Code code = new Code();
+        int random = code.createRandom();
+        return random;
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
@@ -31,16 +31,23 @@ public class SendEmailEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
     public void handle(SendEmailEvent event) {
-        codePort.saveWithExpiration(event.getEmail(), Code.create(), expiredTime);
+        int randomCode = createRandom();
+        codePort.saveWithExpiration(event.getEmail(), String.valueOf(randomCode), expiredTime);
         Context context = new Context();
         context.setVariable(
                 MailTemplate.FIND_PASSWORD_MAIL_CONTEXT,
                 URL + MailTemplate.REPLY_TO_FIND_PASSWORD_MAIL_URL);
-        context.setVariable(MailTemplate.FIND_PASSWORD_EMAIL, "?email=" + event.getEmail());
+        context.setVariable(MailTemplate.FIND_PASSWORD_CODE, randomCode);
         emailPort.sendEmail(
                 event.getEmail(),
                 MailTemplate.FIND_PASSWORD_TITLE,
                 MailTemplate.FIND_PASSWORD_TEMPLATE,
                 context);
+    }
+
+    private int createRandom() {
+        Code code = new Code();
+        int random = code.createRandom();
+        return random;
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/SignUpMemberEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/SignUpMemberEventListener.java
@@ -34,15 +34,22 @@ public class SignUpMemberEventListener {
     @Timer
     @Async
     public void handle(SignUpMemberEvent event) {
-        codePort.saveWithExpiration(event.getEmail(), Code.create(), expiredTime);
+        int randomCode = createRandom();
+        codePort.saveWithExpiration(event.getEmail(), String.valueOf(randomCode), expiredTime);
         Context context = new Context();
         context.setVariable(
                 MailTemplate.SIGN_UP_MAIL_CONTEXT, URL + MailTemplate.REPLY_TO_SIGN_UP_MAIL_URL);
-        context.setVariable(MailTemplate.SIGN_UP_EMAIL, "?email=" + event.getEmail());
+        context.setVariable(MailTemplate.SIGN_UP_CODE, randomCode);
         emailPort.sendEmail(
                 event.getEmail(),
                 MailTemplate.SIGN_UP_TITLE,
                 MailTemplate.SIGN_UP_TEMPLATE,
                 context);
+    }
+
+    private int createRandom() {
+        Code code = new Code();
+        int random = code.createRandom();
+        return random;
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/SignUpMemberEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/SignUpMemberEventListener.java
@@ -12,7 +12,6 @@ import com.gaebaljip.exceed.application.domain.member.Code;
 import com.gaebaljip.exceed.application.port.out.member.CodePort;
 import com.gaebaljip.exceed.application.port.out.member.EmailPort;
 import com.gaebaljip.exceed.common.MailTemplate;
-import com.gaebaljip.exceed.common.annotation.Timer;
 import com.gaebaljip.exceed.common.event.SignUpMemberEvent;
 
 import lombok.RequiredArgsConstructor;
@@ -31,7 +30,6 @@ public class SignUpMemberEventListener {
 
     @TransactionalEventListener(classes = SignUpMemberEvent.class)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Timer
     @Async
     public void handle(SignUpMemberEvent event) {
         int randomCode = createRandom();

--- a/src/main/resources/templates/findPassword.html
+++ b/src/main/resources/templates/findPassword.html
@@ -1,15 +1,91 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>Eatceed 비밀번호 찾기</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>비밀번호 찾기 전 이메일 인증</title>
+    <style>
+        /* 기본 스타일 */
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f9f9f9;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            max-width: 600px;
+            margin: 20px auto;
+            background-color: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 20px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            text-align: center; /* 전체 중앙 정렬 */
+        }
+        .email-header {
+            font-size: 20px;
+            font-weight: bold;
+            color: #333333;
+            margin-bottom: 10px;
+        }
+        .email-body {
+            font-size: 16px;
+            line-height: 1.5;
+            color: #555555;
+            margin-bottom: 20px;
+        }
+        .authcode-container {
+            margin: 20px 0;
+        }
+        .authcode-box {
+            background-color: #f4f4f4;
+            color: #1e7d1e; /* 초록색 텍스트 */
+            padding: 10px 20px; /* 텍스트 좌우 여백 */
+            border-radius: 5px;
+            font-size: 20px;
+            font-weight: bold;
+            display: inline-block;
+        }
+        .email-link {
+            color: #007bff;
+            text-decoration: none;
+            font-weight: bold;
+            margin-top: 10px;
+            display: inline-block; /* 링크도 중앙 정렬 */
+        }
+        .email-footer {
+            font-size: 12px;
+            color: #999999;
+            margin-top: 20px;
+            text-align: center;
+        }
+    </style>
 </head>
 <body>
-<h2>비밀번호 변경</h2>
-<p>안녕하세요 체중 증량 어플 Eatceed입니다.</p>
-<p>아래의 링크를 클릭해 비밀번호 찾기 페이지로 이동해주세요.</p>
-<p>인증을 요청하지 않았다면, 이 이메일을 무시하셔도 됩니다.</p>
-<a th:href="${findPasswordLink} + ${email}">비밀번호 변경 링크</a>
-<link rel="shortcut icon" type="image/x-icon" href="data:image/x-icon;," >
+<div class="email-container">
+    <!-- 헤더 -->
+    <div class="email-header">비밀번호 찾기</div>
+
+    <!-- 본문 -->
+    <div class="email-body">
+        안녕하세요 체중 증량 어플 <strong>Eatceed</strong>입니다.<br><br>
+        아래의 링크를 통해 인증 코드를 입력해주세요. 인증된 후에 비밀번호 찾기가 진행됩니다.
+    </div>
+
+    <!-- 인증 코드 -->
+    <div class="authcode-container">
+        <div class="authcode-box" th:text="${code}">인증 코드</div> <!-- 인증 코드 값 표시 -->
+    </div>
+
+    <!-- 인증 링크 -->
+    <div class="email-body">
+        <a th:href="${findPasswordLink}" class="email-link">이메일 인증 링크</a> <!-- 인증 링크 동적 적용 -->
+    </div>
+
+    <!-- 푸터 -->
+    <div class="email-footer">
+        인증을 요청하지 않았다면, 이 이메일을 무시하셔도 됩니다.
+    </div>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -1,15 +1,91 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>Eatceed 이메일 인증</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증</title>
+    <style>
+        /* 기본 스타일 */
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f9f9f9;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            max-width: 600px;
+            margin: 20px auto;
+            background-color: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 20px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            text-align: center; /* 전체 중앙 정렬 */
+        }
+        .email-header {
+            font-size: 20px;
+            font-weight: bold;
+            color: #333333;
+            margin-bottom: 10px;
+        }
+        .email-body {
+            font-size: 16px;
+            line-height: 1.5;
+            color: #555555;
+            margin-bottom: 20px;
+        }
+        .authcode-container {
+            margin: 20px 0;
+        }
+        .authcode-box {
+            background-color: #f4f4f4;
+            color: #1e7d1e; /* 초록색 텍스트 */
+            padding: 10px 20px; /* 텍스트 좌우 여백 */
+            border-radius: 5px;
+            font-size: 20px;
+            font-weight: bold;
+            display: inline-block;
+        }
+        .email-link {
+            color: #007bff;
+            text-decoration: none;
+            font-weight: bold;
+            margin-top: 10px;
+            display: inline-block; /* 링크도 중앙 정렬 */
+        }
+        .email-footer {
+            font-size: 12px;
+            color: #999999;
+            margin-top: 20px;
+            text-align: center;
+        }
+    </style>
 </head>
 <body>
-<h2>이메일 인증</h2>
-<p>안녕하세요 체중 증량 어플 Eatceed입니다.</p>
-<p>아래의 링크를 통해 이메일 주소를 인증해주세요. 인증되면 회원가입이 완료됩니다.</p>
-<p>인증을 요청하지 않았다면, 이 이메일을 무시하셔도 됩니다.</p>
-<a th:href="${signupLink} + ${email}">이메일 인증 링크</a>
-<link rel="shortcut icon" type="image/x-icon" href="data:image/x-icon;," >
+<div class="email-container">
+    <!-- 헤더 -->
+    <div class="email-header">이메일 인증</div>
+
+    <!-- 본문 -->
+    <div class="email-body">
+        안녕하세요 체중 증량 어플 <strong>Eatceed</strong>입니다.<br><br>
+        아래의 링크를 통해 인증 코드를 입력해주세요. 인증되면 회원가입이 완료됩니다.
+    </div>
+
+    <!-- 인증 코드 -->
+    <div class="authcode-container">
+        <div class="authcode-box" th:text="${code}">인증 코드</div> <!-- 인증 코드 값 표시 -->
+    </div>
+
+    <!-- 인증 링크 -->
+    <div class="email-body">
+        <a th:href="${signupLink}" class="email-link">이메일 인증 링크</a> <!-- 인증 링크 동적 적용 -->
+    </div>
+
+    <!-- 푸터 -->
+    <div class="email-footer">
+        인증을 요청하지 않았다면, 이 이메일을 무시하셔도 됩니다.
+    </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/576

## 🔑 주요 변경사항

이메일 인증 방식이 변경되었습니다.
기존에는 딥링크에 인증 코드를 포함시켜 AOS에게 인증 코드를 전달하는 방식이었는데, 이 방식은 인증 코드를 암호화 및 복호화하는 시간이 포함되어 CPU 자원을 잡아먹고 속도 또한 느렸습니다.

따라서, 사용자가 이메일에 보여지는 인증코드를 사용자가 직접 앱 내 화면에 입력하는 방식으로 수정하였습니다.

- 6자리 랜덤 인증 코드를 생성하는 클래스(8a092a52fc462eab68703fec3659b209fd9525bc)
-  email context에 인증 코드를 포함 ([67cdaaf](https://github.com/JNU-econovation/EATceed-BE/pull/578/commits/67cdaaf6c15bae35d8ac6977fd0f5c7ba67250d3))
-  딥링크에 인증 코드를 포함시키는 코드 제거 ([d89da5e](https://github.com/JNU-econovation/EATceed-BE/pull/578/commits/d89da5ec9f5347ccf3af69f68e428b21a8566b82))
- 단순 인증 코드끼리 비교하는 방식으로 수정 ([fe0ae43](https://github.com/JNU-econovation/EATceed-BE/pull/578/commits/fe0ae43e6e033d6eccd1269b4aaea1fd204d17c5))
