### PR TITLE
[BE/FIX] 식사 도메인의 영양소 계산 로직 수정

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/application/domain/meal/GStrategy.java
+++ b/src/main/java/com/gaebaljip/exceed/application/domain/meal/GStrategy.java
@@ -3,6 +3,6 @@ package com.gaebaljip.exceed.application.domain.meal;
 public class GStrategy implements MeasureStrategy {
     @Override
     public double measure(double nutrients, Unit unit, double servingSize) {
-        return (nutrients / servingSize) * unit.getG();
+        return (unit.getG() / servingSize) * nutrients;
     }
 }


### PR DESCRIPTION
# 📌관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/588

# 🔑 주요 변경사항

> 사용자는 "g" 혹은 "인분" 단위로 음식 등록 진행

"g"으로 등록할 시 유저가 선택한 "g"을 serving_size와의 비율을 통해 수식 진행. 예를 들어, serving_size가 400인데 사용자는 200g을 선택할 경우 200/400(유저가 선택한 g / serving_size)를 해서 1/2의 값을 얻음. 이후 영양성분 및 칼로리에 1/2를 곱하여 적용

"인분"으로 등록할 시 예를 들어, 1.3(이럴 일은 거의 없겠지만)인분일 경우 유저가 선택한 "인분"을 그대로 영양성분 및 칼로리에 1.3을 곱하여 적용


주요 계산 로직을 잘못 이해하여 수정합니다..😅