### PR TITLE
[BE/FEAT]  켈린더 상세 API에 식사별 총 칼로리 값 추가

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/adapter/out/aws/S3Adapter.java
+++ b/src/main/java/com/gaebaljip/exceed/adapter/out/aws/S3Adapter.java
@@ -26,7 +26,7 @@ public class S3Adapter implements PresignedUrlPort {
     public static final String CONTENT_TYPE_PREFIX = "image/";
 
     @Override
-    public String query(Long memberId, Long mealId) {
+    public String get(Long memberId, Long mealId) {
         GetObjectRequest getObjectRequest =
                 GetObjectRequest.builder().bucket(bucketName).key(memberId + "_" + mealId).build();
         GetObjectPresignRequest presignRequest =
@@ -39,7 +39,7 @@ public class S3Adapter implements PresignedUrlPort {
     }
 
     @Override
-    public String command(Long memberId, Long mealId, String fileName) {
+    public String put(Long memberId, Long mealId, String fileName) {
         PutObjectRequest putObjectRequest =
                 PutObjectRequest.builder()
                         .bucket(bucketName)

--- a/src/main/java/com/gaebaljip/exceed/application/port/out/meal/PresignedUrlPort.java
+++ b/src/main/java/com/gaebaljip/exceed/application/port/out/meal/PresignedUrlPort.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public interface PresignedUrlPort {
-    String query(Long mealId, Long memberId);
+    String get(Long mealId, Long memberId);
 
-    String command(Long memberId, Long mealId, String fileName);
+    String put(Long memberId, Long mealId, String fileName);
 }

--- a/src/main/java/com/gaebaljip/exceed/application/service/meal/GetSpecificMealService.java
+++ b/src/main/java/com/gaebaljip/exceed/application/service/meal/GetSpecificMealService.java
@@ -48,8 +48,7 @@ public class GetSpecificMealService implements GetSpecificMealQuery {
                                 mealEntity ->
                                         MealRecordDTO.of(
                                                 mealEntity,
-                                                presignedUrlPort.query(
-                                                        memberId, mealEntity.getId())))
+                                                presignedUrlPort.get(memberId, mealEntity.getId())))
                         .toList();
         DailyMealFoods dailyMealFoods =
                 dailyMealPort.queryMealFoods(

--- a/src/main/java/com/gaebaljip/exceed/application/service/meal/GetSpecificMealService.java
+++ b/src/main/java/com/gaebaljip/exceed/application/service/meal/GetSpecificMealService.java
@@ -63,6 +63,10 @@ public class GetSpecificMealService implements GetSpecificMealQuery {
                 .mealType(mealEntity.getMealType())
                 .time(mealEntity.getCreatedDate().toLocalTime())
                 .imageUri(presignedUrlPort.query(memberId, mealEntity.getId()))
+                .totalCalories(
+                        mealEntity.getMealFoodEntities().stream()
+                                .mapToDouble(mealFood -> mealFood.getAdjustedCalorie())
+                                .sum())
                 .foodDTOS(
                         mealEntity.getMealFoodEntities().stream()
                                 .map(

--- a/src/main/java/com/gaebaljip/exceed/application/service/meal/GetSpecificMealService.java
+++ b/src/main/java/com/gaebaljip/exceed/application/service/meal/GetSpecificMealService.java
@@ -2,7 +2,6 @@ package com.gaebaljip.exceed.application.service.meal;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +13,6 @@ import com.gaebaljip.exceed.application.port.out.meal.DailyMealPort;
 import com.gaebaljip.exceed.application.port.out.meal.PresignedUrlPort;
 import com.gaebaljip.exceed.common.dto.CurrentMealDTO;
 import com.gaebaljip.exceed.common.dto.DailyMealDTO;
-import com.gaebaljip.exceed.common.dto.FoodDTO;
 import com.gaebaljip.exceed.common.dto.MealRecordDTO;
 import com.gaebaljip.exceed.common.dto.SpecificMealDTO;
 
@@ -45,7 +43,14 @@ public class GetSpecificMealService implements GetSpecificMealQuery {
     public SpecificMealDTO execute(Long memberId, LocalDateTime date) {
         List<MealEntity> mealEntities = dailyMealPort.queryMeals(new DailyMealDTO(memberId, date));
         List<MealRecordDTO> mealRecordDTOS =
-                mealEntities.stream().map(meal -> createMealRecord(meal, memberId)).toList();
+                mealEntities.stream()
+                        .map(
+                                mealEntity ->
+                                        MealRecordDTO.of(
+                                                mealEntity,
+                                                presignedUrlPort.query(
+                                                        memberId, mealEntity.getId())))
+                        .toList();
         DailyMealFoods dailyMealFoods =
                 dailyMealPort.queryMealFoods(
                         mealEntities.stream().map(meal -> meal.getId()).toList());
@@ -56,26 +61,5 @@ public class GetSpecificMealService implements GetSpecificMealQuery {
                         dailyMealFoods.calculateCurrentProtein(),
                         dailyMealFoods.calculateCurrentFat());
         return SpecificMealDTO.of(currentMealDTO, mealRecordDTOS);
-    }
-
-    private MealRecordDTO createMealRecord(MealEntity mealEntity, Long memberId) {
-        return MealRecordDTO.builder()
-                .mealType(mealEntity.getMealType())
-                .time(mealEntity.getCreatedDate().toLocalTime())
-                .imageUri(presignedUrlPort.query(memberId, mealEntity.getId()))
-                .totalCalories(
-                        mealEntity.getMealFoodEntities().stream()
-                                .mapToDouble(mealFood -> mealFood.getAdjustedCalorie())
-                                .sum())
-                .foodDTOS(
-                        mealEntity.getMealFoodEntities().stream()
-                                .map(
-                                        mealFood ->
-                                                FoodDTO.builder()
-                                                        .id(mealFood.getFoodEntity().getId())
-                                                        .name(mealFood.getFoodEntity().getName())
-                                                        .build())
-                                .collect(Collectors.toList()))
-                .build();
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/application/service/meal/UploadImageService.java
+++ b/src/main/java/com/gaebaljip/exceed/application/service/meal/UploadImageService.java
@@ -20,7 +20,7 @@ public class UploadImageService implements UploadImageUsecase {
     @Override
     public String execute(UploadImageCommand uploadImageCommand) {
         validateExt(uploadImageCommand.fileName());
-        return presignedUrlPort.command(
+        return presignedUrlPort.put(
                 uploadImageCommand.memberId(),
                 uploadImageCommand.mealId(),
                 uploadImageCommand.fileName());

--- a/src/main/java/com/gaebaljip/exceed/common/dto/MealRecordDTO.java
+++ b/src/main/java/com/gaebaljip/exceed/common/dto/MealRecordDTO.java
@@ -4,7 +4,9 @@ import java.time.LocalTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.gaebaljip.exceed.application.domain.meal.MealType;
+import com.gaebaljip.exceed.common.CustomDoubleSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -17,6 +19,7 @@ public record MealRecordDTO(
                         timezone = "Asia/Seoul")
                 LocalTime time,
         MealType mealType,
+        @JsonSerialize(using = CustomDoubleSerializer.class) Double totalCalories,
         String imageUri,
         List<FoodDTO> foodDTOS) {
 

--- a/src/main/java/com/gaebaljip/exceed/common/dto/MealRecordDTO.java
+++ b/src/main/java/com/gaebaljip/exceed/common/dto/MealRecordDTO.java
@@ -2,9 +2,11 @@ package com.gaebaljip.exceed.common.dto;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.gaebaljip.exceed.application.domain.meal.MealEntity;
 import com.gaebaljip.exceed.application.domain.meal.MealType;
 import com.gaebaljip.exceed.common.CustomDoubleSerializer;
 
@@ -22,6 +24,26 @@ public record MealRecordDTO(
         @JsonSerialize(using = CustomDoubleSerializer.class) Double totalCalories,
         String imageUri,
         List<FoodDTO> foodDTOS) {
+    public static MealRecordDTO of(MealEntity mealEntity, String imageUri) {
+        return MealRecordDTO.builder()
+                .mealType(mealEntity.getMealType())
+                .time(mealEntity.getCreatedDate().toLocalTime())
+                .imageUri(imageUri)
+                .totalCalories(
+                        mealEntity.getMealFoodEntities().stream()
+                                .mapToDouble(mealFood -> mealFood.getAdjustedCalorie())
+                                .sum())
+                .foodDTOS(
+                        mealEntity.getMealFoodEntities().stream()
+                                .map(
+                                        mealFood ->
+                                                FoodDTO.builder()
+                                                        .id(mealFood.getFoodEntity().getId())
+                                                        .name(mealFood.getFoodEntity().getName())
+                                                        .build())
+                                .collect(Collectors.toList()))
+                .build();
+    }
 
     @Builder
     public MealRecordDTO {}


### PR DESCRIPTION
# 📌관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/590

# 🔑 주요 변경사항

- MealRecordDTO에 totalCalories 필드 추가
- Service Layer에서 DTO 생성하던 코드 DTO 안에서 자신이 직접 생성하도록 리팩토링