### PR TITLE
[BE/FIX] 유지 및 목표 단/탄/지 구하는 수식 수정

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/application/domain/member/Member.java
+++ b/src/main/java/com/gaebaljip/exceed/application/domain/member/Member.java
@@ -34,35 +34,35 @@ public class Member {
         }
     }
 
-    public double measureMaintainCarbohydrate() {
-        return measureBMR() / 5;
-    }
-
-    public double measureMaintainProtein() {
-        return measureBMR() / 3;
-    }
-
-    public double measureMaintainFat() {
-        return measureBMR() / 2;
-    }
-
     public double measureTDEE() {
         return measureBMR() * activity.getValue();
     }
 
-    public double measureTargetCarbohydrate() {
-        return measureTargetCalorie() / 5;
+    public double measureMaintainCarbohydrate() {
+        return measureTDEE() * 0.5 / 4;
     }
 
-    public double measureTargetProtein() {
-        return measureTargetCalorie() / 3;
+    public double measureMaintainProtein() {
+        return measureTDEE() * 0.2 / 4;
     }
 
-    public double measureTargetFat() {
-        return measureTargetCalorie() / 2;
+    public double measureMaintainFat() {
+        return measureTDEE() * 0.3 / 9;
     }
 
     public double measureTargetCalorie() {
         return measureTDEE() + 500;
+    }
+
+    public double measureTargetCarbohydrate() {
+        return measureTargetCalorie() * 0.5 / 4;
+    }
+
+    public double measureTargetProtein() {
+        return measureTargetCalorie() * 0.2 / 4;
+    }
+
+    public double measureTargetFat() {
+        return measureTargetCalorie() * 0.3 / 9;
     }
 }


### PR DESCRIPTION
# 📌관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/592

# 🔑 주요 변경사항

g과 kcal를 고려하여 수식을 수정하였습니다.

**유지 단탄지 수식**

탄수화물 : TDEE×0.5/4
단백질 : TDEE×0.2/4
지방 : TDEE×0.3/9

**목표 단탄지 수식**

탄수화물 : (TDEE+500)×0.5/4
단백질 : (TDEE+500)×0.2/4
지방 : (TDEE+500)×0.3/9