### PR TITLE
[BE/FEAT] 스웨거 비밀번호 설정

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/common/EatCeedStaticMessage.java
+++ b/src/main/java/com/gaebaljip/exceed/common/EatCeedStaticMessage.java
@@ -5,4 +5,14 @@ public class EatCeedStaticMessage {
     public static final String REDIS_REFRESH_TOKEN_KEY = "refresh_";
 
     public static final String REFRESH_TOKEN = "refreshToken";
+    public static final String[] SwaggerPatterns = {
+        "/swagger-resources/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/v3/api-docs/**",
+        "/v3/api-docs",
+        "/api-docs/**",
+        "/api-docs",
+        "/docs/api-doc.html"
+    };
 }

--- a/src/main/java/com/gaebaljip/exceed/common/helper/SpringEnvironmentHelper.java
+++ b/src/main/java/com/gaebaljip/exceed/common/helper/SpringEnvironmentHelper.java
@@ -1,0 +1,46 @@
+package com.gaebaljip.exceed.common.helper;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SpringEnvironmentHelper {
+
+    private final Environment environment;
+
+    private final String PROD = "prod";
+    private final String STAGING = "staging";
+    private final String DEV = "dev";
+    private final List<String> PROD_AND_STAGING = List.of("staging", "prod");
+
+    public Boolean isProdProfile() {
+        String[] activeProfiles = environment.getActiveProfiles();
+        List<String> currentProfile = Arrays.stream(activeProfiles).toList();
+        return currentProfile.contains(PROD);
+    }
+
+    public Boolean isStagingProfile() {
+        String[] activeProfiles = environment.getActiveProfiles();
+        List<String> currentProfile = Arrays.stream(activeProfiles).toList();
+        return currentProfile.contains(STAGING);
+    }
+
+    public Boolean isDevProfile() {
+        String[] activeProfiles = environment.getActiveProfiles();
+        List<String> currentProfile = Arrays.stream(activeProfiles).toList();
+        return currentProfile.contains(DEV);
+    }
+
+    public Boolean isProdAndStagingProfile() {
+        String[] activeProfiles = environment.getActiveProfiles();
+        List<String> currentProfile = Arrays.stream(activeProfiles).toList();
+        return CollectionUtils.containsAny(PROD_AND_STAGING, currentProfile);
+    }
+}

--- a/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/gaebaljip/exceed/common/security/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsUtils;
 
+import com.gaebaljip.exceed.common.helper.SpringEnvironmentHelper;
 import com.gaebaljip.exceed.common.security.domain.JwtManager;
 import com.gaebaljip.exceed.common.security.domain.JwtResolver;
 import com.gaebaljip.exceed.common.security.exception.JwtAccessDeniedHandler;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final MemberDetailService memberDetailService;
     private final JwtAuthenticationPoint jwtAuthenticationPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final SpringEnvironmentHelper springEnvironmentHelper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -77,12 +79,22 @@ public class SecurityConfig {
                 .permitAll()
                 .antMatchers(HttpMethod.POST, "/v1/auth/login", "/v1/auth/refresh")
                 .permitAll()
+                .antMatchers(
+                        "/swagger-resources/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/v3/api-docs/**",
+                        "/v3/api-docs",
+                        "/api-docs/**",
+                        "/api-docs")
+                .permitAll()
                 .anyRequest()
                 .authenticated();
 
         // jwt filter 설정
         http.addFilterBefore(
-                new JwtAuthenticationFilter(jwtManager, jwtResolver, memberDetailService),
+                new JwtAuthenticationFilter(
+                        jwtManager, jwtResolver, memberDetailService, springEnvironmentHelper),
                 UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
@@ -91,16 +103,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) ->
                 web.ignoring()
-                        .antMatchers("/docs/api-doc.html")
                         .antMatchers("/favicon.*", "/*/icon-*")
-                        .antMatchers(
-                                "/swagger-resources/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/v3/api-docs/**",
-                                "/v3/api-docs",
-                                "/api-docs/**",
-                                "/api-docs")
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/common/security/exception/JwtAuthenticationPoint.java
+++ b/src/main/java/com/gaebaljip/exceed/common/security/exception/JwtAuthenticationPoint.java
@@ -36,11 +36,13 @@ public class JwtAuthenticationPoint implements AuthenticationEntryPoint {
             HttpServletResponse response,
             AuthenticationException authException)
             throws IOException {
-        if (request.getAttribute("exception") == null) {
+        Object exceptionAttribute = request.getAttribute("javax.servlet.error.exception");
+        if (exceptionAttribute == null) {
             handleAuthenticationException(response);
+        } else if (exceptionAttribute instanceof Exception exception) {
+            resolver.resolveException(request, response, null, exception);
         } else {
-            resolver.resolveException(
-                    request, response, null, (Exception) request.getAttribute("exception"));
+            handleAuthenticationException(response);
         }
     }
 

--- a/src/main/java/com/gaebaljip/exceed/common/security/exception/JwtAuthenticationPoint.java
+++ b/src/main/java/com/gaebaljip/exceed/common/security/exception/JwtAuthenticationPoint.java
@@ -36,13 +36,18 @@ public class JwtAuthenticationPoint implements AuthenticationEntryPoint {
             HttpServletResponse response,
             AuthenticationException authException)
             throws IOException {
-        Object exceptionAttribute = request.getAttribute("javax.servlet.error.exception");
-        if (exceptionAttribute == null) {
+
+        if (request.getAttribute("swaggerCannotProdException") != null) {
+            resolver.resolveException(
+                    request,
+                    response,
+                    null,
+                    (Exception) request.getAttribute("swaggerCannotProdException"));
+        } else if (request.getAttribute("exception") == null) {
             handleAuthenticationException(response);
-        } else if (exceptionAttribute instanceof Exception exception) {
-            resolver.resolveException(request, response, null, exception);
         } else {
-            handleAuthenticationException(response);
+            resolver.resolveException(
+                    request, response, null, (Exception) request.getAttribute("exception"));
         }
     }
 

--- a/src/main/java/com/gaebaljip/exceed/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gaebaljip/exceed/common/security/filter/JwtAuthenticationFilter.java
@@ -46,6 +46,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // prod 환경에서 swagger 요청을 차단
         if (Boolean.TRUE.equals(springEnvironmentHelper.isProdProfile())
                 && isSwaggerRequest(request)) {
+            request.setAttribute(
+                    "swaggerCannotProdException", SwaggerCannotProdException.EXCEPTION);
             throw SwaggerCannotProdException.EXCEPTION;
         }
 

--- a/src/main/java/com/gaebaljip/exceed/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gaebaljip/exceed/common/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.gaebaljip.exceed.common.security.filter;
 
+import static com.gaebaljip.exceed.common.EatCeedStaticMessage.SwaggerPatterns;
+
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,12 +15,15 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.gaebaljip.exceed.common.helper.SpringEnvironmentHelper;
 import com.gaebaljip.exceed.common.security.domain.JwtManager;
 import com.gaebaljip.exceed.common.security.domain.JwtResolver;
 import com.gaebaljip.exceed.common.security.domain.MemberDetails;
 import com.gaebaljip.exceed.common.security.service.MemberDetailService;
+import com.gaebaljip.exceed.common.swagger.SwaggerCannotProdException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,12 +35,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtManager jwtManager;
     private final JwtResolver jwtResolver;
     private final MemberDetailService memberDetailService;
+    private final SpringEnvironmentHelper springEnvironmentHelper;
     private final List<String> excludeUrl = List.of("/actuator", "/v1/health");
 
     @Override
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+
+        // prod 환경에서 swagger 요청을 차단
+        if (Boolean.TRUE.equals(springEnvironmentHelper.isProdProfile())
+                && isSwaggerRequest(request)) {
+            throw SwaggerCannotProdException.EXCEPTION;
+        }
 
         final String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
@@ -83,5 +95,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         }
         return flag;
+    }
+
+    private boolean isSwaggerRequest(HttpServletRequest request) {
+        String servletPath = request.getServletPath();
+        return PatternMatchUtils.simpleMatch(SwaggerPatterns, servletPath);
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/common/swagger/SwaggerCannotProdException.java
+++ b/src/main/java/com/gaebaljip/exceed/common/swagger/SwaggerCannotProdException.java
@@ -1,0 +1,11 @@
+package com.gaebaljip.exceed.common.swagger;
+
+import com.gaebaljip.exceed.common.exception.EatCeedException;
+
+public class SwaggerCannotProdException extends EatCeedException {
+    public static EatCeedException EXCEPTION = new SwaggerCannotProdException();
+
+    private SwaggerCannotProdException() {
+        super(SwaggerError.SWAGGER_CANNOT_PROD);
+    }
+}

--- a/src/main/java/com/gaebaljip/exceed/common/swagger/SwaggerError.java
+++ b/src/main/java/com/gaebaljip/exceed/common/swagger/SwaggerError.java
@@ -1,0 +1,33 @@
+package com.gaebaljip.exceed.common.swagger;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import com.gaebaljip.exceed.common.Error;
+import com.gaebaljip.exceed.common.exception.BaseError;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SwaggerError implements BaseError {
+    SWAGGER_CANNOT_PROD(400, "SWAGGER_400_1", "운영환경에서는 Swagger를 볼 수 없습니다."),
+    ;
+
+    private final Integer status;
+    private final String code;
+    private final String reason;
+
+    @Override
+    public Error getError() {
+        return Error.builder().reason(reason).code(code).status(status.toString()).build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}


### PR DESCRIPTION
📌관련 이슈
close #603 
🔑 주요 변경사항
1. prod 환경에서 swagger 사용하지 못하게 막기
- JwtAuthenticationFilter에서 profile이 prod 이고 request가 Swagger 관련이면 SwaggerCannotProdException 을 throw 한다.
2. swagger 요청을 web ignore 하지않고 permitAll()
- swagger 요청이 JwtAuthenticationFilter를 거쳐야 함으로 ignore 하지않고 permitAll 해줌
### 리뷰어에게
1. https://devnm.tistory.com/25 를 참고하여 스웨거 비밀번호 설정을 하려고 했으나 JwtAuthenticationPoint와 충돌이 있는 것 같고 swagger-ui/index.html은 200으로 정상적으로 응답을 하나 다른 swagger 요청(css, api-docs 등) 들이 요청되지 않은 현상이 발생함 -> 빈화면만 뜸 
자꾸 이런 현상이 떠서 그냥 prod 환경에서는 swagger를 사용하지 못하는 방식으로 변경

2. JwtAutehnticationPoint에서 기존에는 request.getAttribute("exception") 이렇게 되있었는데 SwaggerCannotProdException 을 catch 하지못하고 있길래 디버깅 해보니 request의 attribute에 key가 exception으로 되어있는게 아닌 javax.servlet.error.exception 로 되어있어서 이걸로 수정하니 catch 하여 정상적으로 동작함
- 이전에 exception으로 했을 때 정상 동작을 했나요?  아니면 항상 if (request.getAttribute("exception") == null) 이 부분에 걸려서 체크하지 못한걸까요??