### PR TITLE
[BE/FEAT] 운영 로그 masking 처리하기

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/common/log/MaskingPatternLayout.java
+++ b/src/main/java/com/gaebaljip/exceed/common/log/MaskingPatternLayout.java
@@ -1,0 +1,48 @@
+package com.gaebaljip.exceed.common.log;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class MaskingPatternLayout extends PatternLayout {
+
+    private Pattern multilinePattern;
+    private List<String> maskPatterns = new ArrayList<>();
+
+    public void addMaskPattern(String maskPattern) {
+        maskPatterns.add(maskPattern);
+        multilinePattern =
+                Pattern.compile(
+                        maskPatterns.stream().collect(Collectors.joining("|")), Pattern.MULTILINE);
+    }
+
+    @Override
+    public String doLayout(ILoggingEvent event) {
+        return maskMessage(super.doLayout(event));
+    }
+
+    private String maskMessage(String message) {
+        if (multilinePattern == null) {
+            return message;
+        }
+        StringBuilder sb = new StringBuilder(message);
+        Matcher matcher = multilinePattern.matcher(sb);
+        while (matcher.find()) {
+            IntStream.rangeClosed(1, matcher.groupCount())
+                    .forEach(
+                            group -> {
+                                if (matcher.group(group) != null) {
+                                    IntStream.range(matcher.start(group), matcher.end(group))
+                                            .forEach(i -> sb.setCharAt(i, '*'));
+                                }
+                            });
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,7 +18,6 @@ spring:
       hibernate:
         show_sql : true
         format_sql: true
-        use_sql_comments: true
 
 
 cloud:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,11 +14,7 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
       dialect: org.hibernate.dialect.MariaDBDialect
       ddl-auto: validate
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-        use_sql_comments: true
+
 cloud:
   aws:
     credentials:
@@ -83,14 +79,6 @@ server:
   tomcat:
     mbeanregistry:
       enabled: true
-
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql: info
 
 org:
   quartz:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -20,6 +20,7 @@
             </layout>
         </encoder>
     </appender>
+
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.gaebaljip.exceed.common.log.MaskingPatternLayout">
@@ -41,6 +42,7 @@
             <totalSizeCap>100MB</totalSizeCap>
         </rollingPolicy>
     </appender>
+
 
     <springProfile name="local">
         <logger name="com.gaebaljip.exceed" level="DEBUG" />

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,13 +6,33 @@
     <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n" />
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.gaebaljip.exceed.common.log.MaskingPatternLayout">
+                <maskPattern>\"(?i).*email.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <maskPattern>\"(?i).*password.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <maskPattern>\"(?i).*height.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*weight.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*targetWeight.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*age.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*etc.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <maskPattern>\"(?i).*activity.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </layout>
         </encoder>
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.gaebaljip.exceed.common.log.MaskingPatternLayout">
+                <maskPattern>\"(?i).*email.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <maskPattern>\"(?i).*password.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <maskPattern>\"(?i).*height.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*weight.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*targetWeight.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*age.*"\s*:\s*(\d+)</maskPattern>
+                <maskPattern>\"(?i).*etc.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <maskPattern>\"(?i).*activity.*"\s*:\s*\"(.*?)\"</maskPattern>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </layout>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./log/%d{yyyy-MM-dd}.%i.log</fileNamePattern>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,8 +2,8 @@
 <configuration>
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
 
-    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{REQUEST_ID}] [%thread] %clr(%5level) %cyan(%logger) - %msg%n" />
-    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n" />
+    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %clr([%X{REQUEST_ID}]){magenta} [%thread] %clr(%5level) %clr(%20logger){cyan} - %msg%n" />
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{REQUEST_ID}] [%thread] %5level %20logger - %msg%n" />
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,8 +36,9 @@
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./log/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
         </rollingPolicy>
     </appender>
 

--- a/src/test/java/com/gaebaljip/exceed/common/SchemaValidationTest.java
+++ b/src/test/java/com/gaebaljip/exceed/common/SchemaValidationTest.java
@@ -1,36 +1,37 @@
-//package com.gaebaljip.exceed.common;
+// package com.gaebaljip.exceed.common;
 //
-//import java.io.IOException;
-//import java.nio.file.Files;
-//import java.nio.file.Paths;
-//import java.sql.Connection;
-//import java.sql.SQLException;
-//import java.sql.Statement;
+// import java.io.IOException;
+// import java.nio.file.Files;
+// import java.nio.file.Paths;
+// import java.sql.Connection;
+// import java.sql.SQLException;
+// import java.sql.Statement;
 //
-//import org.junit.jupiter.api.AfterAll;
-//import org.junit.jupiter.api.BeforeAll;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-//import org.springframework.context.annotation.Import;
-//import org.springframework.test.context.DynamicPropertyRegistry;
-//import org.springframework.test.context.DynamicPropertySource;
-//import org.testcontainers.containers.GenericContainer;
-//import org.testcontainers.containers.MariaDBContainer;
-//import org.testcontainers.utility.DockerImageName;
+// import org.junit.jupiter.api.AfterAll;
+// import org.junit.jupiter.api.BeforeAll;
+// import org.junit.jupiter.api.Test;
+// import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+// import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+// import org.springframework.context.annotation.Import;
+// import org.springframework.test.context.DynamicPropertyRegistry;
+// import org.springframework.test.context.DynamicPropertySource;
+// import org.testcontainers.containers.GenericContainer;
+// import org.testcontainers.containers.MariaDBContainer;
+// import org.testcontainers.utility.DockerImageName;
 //
-//import com.gaebaljip.exceed.config.QueryDslConfig;
+// import com.gaebaljip.exceed.config.QueryDslConfig;
 //
-//@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
-//@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-//@Import(QueryDslConfig.class)
-//public class SchemaValidationTest {
+// @DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
+// @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// @Import(QueryDslConfig.class)
+// public class SchemaValidationTest {
 //
 //    private static MariaDBContainer<?> schemaValidationMariaDB;
 //    private static GenericContainer<?> redisContainer;
 //
 //    private static String getAbsolutePath() {
-//        String relativePath = "resources/gaebaljip-develop-environment/mariadb-init/01_schema.sql";
+//        String relativePath =
+// "resources/gaebaljip-develop-environment/mariadb-init/01_schema.sql";
 //        String currentDir = System.getProperty("user.dir");
 //        return Paths.get(currentDir, relativePath).normalize().toAbsolutePath().toString();
 //    }
@@ -92,4 +93,4 @@
 //
 //    @Test
 //    public void testSchemaValidity() {}
-//}
+// }


### PR DESCRIPTION
# 📌관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/605

# 🔑 주요 변경사항

- logback-spring.xml에서 email, password, height, weight, targetWeight, age, etc, activity을 마스킹 처리
- logback-spring.xml에서 maxFileSize를 10MB 설정
- logback-spring.xml에서 totalSizeCap을 100MB로 설정
![스크린샷 2024-12-30 오후 4 00 42](https://github.com/user-attachments/assets/f76ba97b-ed63-46ba-94c9-c467af6ea9b0)
![스크린샷 2024-12-30 오후 3 57 52](https://github.com/user-attachments/assets/d4fc168a-e69d-4d1f-8047-1ef242864942)


