### PR TITLE
[BE/FEAT] 회원탈퇴시 이메일 발송

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
+++ b/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
@@ -3,10 +3,13 @@ package com.gaebaljip.exceed.common;
 public class MailTemplate {
     public static final String SIGN_UP_TEMPLATE = "signup";
     public static final String FIND_PASSWORD_TEMPLATE = "findPassword";
-
+    public static final String WITHDRAW_TEMPLATE = "withdraw";
     public static final String SIGN_UP_TITLE = "Eatceed 회원가입 인증 메일";
     public static final String FIND_PASSWORD_TITLE = "Eatceed 비밀번호 찾기 메일";
+
     public static final String SIGN_UP_MAIL_CONTEXT = "signupLink";
+    public static final String WITHDRAW_TITLE = "회원 탈퇴 완료 안내";
+    public static final String POLICY_MAIL_CONTEXT = "policyLink";
     public static final String FIND_PASSWORD_MAIL_CONTEXT = "findPasswordLink";
     public static final String SIGN_UP_CODE = "code";
     public static final String SIGN_UP_EMAIL = "email";

--- a/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
+++ b/src/main/java/com/gaebaljip/exceed/common/MailTemplate.java
@@ -10,6 +10,7 @@ public class MailTemplate {
     public static final String SIGN_UP_MAIL_CONTEXT = "signupLink";
     public static final String WITHDRAW_TITLE = "회원 탈퇴 완료 안내";
     public static final String POLICY_MAIL_CONTEXT = "policyLink";
+    public static final String CONTACT_MAIL_CONTEXT = "contactEmail";
     public static final String FIND_PASSWORD_MAIL_CONTEXT = "findPasswordLink";
     public static final String SIGN_UP_CODE = "code";
     public static final String SIGN_UP_EMAIL = "email";

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/DeleteMemberEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/DeleteMemberEventListener.java
@@ -38,6 +38,9 @@ public class DeleteMemberEventListener {
     @Value("${exceed.deepLink.policy}")
     private String POLICY_URL;
 
+    @Value("${exceed.contact.email}")
+    private String CONTACT_EMAIL;
+
     @EventListener(classes = DeleteMemberEvent.class)
     @Transactional
     public void handle(DeleteMemberEvent event) {
@@ -77,6 +80,7 @@ public class DeleteMemberEventListener {
     private void sendEmail(MemberEntity memberEntity) {
         Context context = new Context();
         context.setVariable(MailTemplate.POLICY_MAIL_CONTEXT, POLICY_URL);
+        context.setVariable(MailTemplate.CONTACT_MAIL_CONTEXT, CONTACT_EMAIL);
         emailPort.sendEmail(
                 memberEntity.getEmail(),
                 MailTemplate.WITHDRAW_TITLE,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,6 +45,8 @@ exceed:
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw
     policy: ${EXCEED_POLICY_URL}
+  contact:
+    email: ${EXCEED_CONTACT_EMAIL}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -44,6 +44,7 @@ exceed:
   deepLink :
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw
+    policy: ${EXCEED_POLICY_URL}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -45,6 +45,7 @@ exceed:
   deepLink :
     signUp : eatceed://checkemail
     updatePassword : eatceed://changepw
+    policy: ${EXCEED_POLICY_URL}
 
 # swagger
 springdoc:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,6 +46,8 @@ exceed:
     signUp : eatceed://checkemail
     updatePassword : eatceed://changepw
     policy: ${EXCEED_POLICY_URL}
+  contact:
+    email: ${EXCEED_CONTACT_EMAIL}
 
 # swagger
 springdoc:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -40,6 +40,7 @@ exceed:
   deepLink :
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw
+    policy: ${EXCEED_POLICY_URL}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -41,6 +41,8 @@ exceed:
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw
     policy: ${EXCEED_POLICY_URL}
+  contact:
+    email: ${EXCEED_CONTACT_EMAIL}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -35,9 +35,9 @@ exceed:
   deepLink :
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw
-    policy: ${EXCEED_POLICY_URL}
+    policy: eatceed://policy
   contact:
-    email: ${EXCEED_CONTACT_EMAIL}
+    email: eatceed@gmail.com
 
 
 encryption:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -35,6 +35,7 @@ exceed:
   deepLink :
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw
+    policy: ${EXCEED_POLICY_URL}
 
 
 encryption:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -36,6 +36,8 @@ exceed:
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw
     policy: ${EXCEED_POLICY_URL}
+  contact:
+    email: ${EXCEED_CONTACT_EMAIL}
 
 
 encryption:

--- a/src/main/resources/templates/withdraw.html
+++ b/src/main/resources/templates/withdraw.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>회원 탈퇴 완료</title>
+  <style>
+    /* 기본 스타일 */
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f9f9f9;
+      margin: 0;
+      padding: 0;
+    }
+    .email-container {
+      max-width: 600px;
+      margin: 20px auto;
+      background-color: #ffffff;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+    .email-header {
+      font-size: 20px;
+      font-weight: bold;
+      color: #333333;
+      margin-bottom: 10px;
+    }
+    .email-body {
+      font-size: 16px;
+      line-height: 1.5;
+      color: #555555;
+      margin-bottom: 20px;
+    }
+    .email-footer {
+      font-size: 12px;
+      color: #999999;
+      margin-top: 20px;
+      text-align: center;
+    }
+    .highlight {
+      font-weight: bold;
+      color: #007bff;
+    }
+    .link {
+      color: #007bff;
+      text-decoration: none;
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body>
+<div class="email-container">
+  <!-- 헤더 -->
+  <div class="email-header">회원 탈퇴 완료 안내</div>
+
+  <!-- 본문 -->
+  <div class="email-body">
+    안녕하세요, <strong>[EATceed]</strong> 팀입니다.<br><br>
+    회원님의 탈퇴 요청이 정상적으로 처리되었음을 안내드립니다.<br><br>
+    회원 탈퇴에 따라 회원님의 개인정보는 <a th:href="${policyLink}" class="link">개인정보 처리방침</a>에 명시된 바에 따라 처리 및 삭제되었습니다.<br><br>
+    서비스 이용 중 불편함을 느끼셨다면, 언제든 의견을 남겨주시면 개선에 참고하겠습니다.<br>
+    추가 문의 사항이 있으시면 아래 이메일로 연락 주시기 바랍니다.<br><br>
+    감사합니다.<br>
+    <strong>[EATceed]</strong> 팀 드림
+  </div>
+
+  <!-- 푸터 -->
+  <div class="email-footer">
+    이 이메일은 회원 탈퇴 요청에 따라 발송되었습니다.<br>
+  </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/withdraw.html
+++ b/src/main/resources/templates/withdraw.html
@@ -61,8 +61,9 @@
     안녕하세요, <strong>[EATceed]</strong> 팀입니다.<br><br>
     회원님의 탈퇴 요청이 정상적으로 처리되었음을 안내드립니다.<br><br>
     회원 탈퇴에 따라 회원님의 개인정보는 <a th:href="${policyLink}" class="link">개인정보 처리방침</a>에 명시된 바에 따라 처리 및 삭제되었습니다.<br><br>
-    서비스 이용 중 불편함을 느끼셨다면, 언제든 의견을 남겨주시면 개선에 참고하겠습니다.<br>
-    추가 문의 사항이 있으시면 아래 이메일로 연락 주시기 바랍니다.<br><br>
+    서비스 이용 중 불편함을 느끼셨다면, 언제든 의견을 남겨주시면 개선에 참고하겠습니다.<br><br>
+    추가 문의 사항이 있으시면 아래 이메일로 연락 주시기 바랍니다.<br>
+    <strong><a th:href="'mailto:' + ${contactEmail}" th:text="${contactEmail}" class="link"></a></strong> <br><br>
     감사합니다.<br>
     <strong>[EATceed]</strong> 팀 드림
   </div>


### PR DESCRIPTION
# 📌관련 이슈

close #612 

# 🔑 주요 변경사항

- 회원탈퇴안내용 html 작성
- 회원탈퇴시 회원탈퇴 안내 메일 발송되도록 수정

# 리뷰어에게
개인정보방침 링크가 아직 없는 것 같아서 env로 주입받을 수 있도록 해놓았습니다. 나중에 링크 만들면 env로 주입시키면 될 것 같아요.
- EXCEED_POLICY_URL=
EXCEED_CONTACT_EMAIL=

<img width="902" alt="image" src="https://github.com/user-attachments/assets/0ecef985-c187-49d5-83cd-2b9f8859d6c5" />

