### PR TITLE
[BE/FIX] 딥링크를 전달하는 API에서 Nginx 404 NOT FOUND 오류 해결

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -40,7 +40,7 @@ jwt:
   secret: ${JWT_SECRET}
 
 exceed:
-  url : https://eatceed.net
+  url : https://eatceed.net/dev
   deepLink :
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -36,7 +36,7 @@ jwt:
   secret: ${JWT_SECRET}
 
 exceed:
-  url : https://eatceed.net
+  url : https://eatceed.net/prod
   deepLink :
     signUp: eatceed://checkemail
     updatePassword: eatceed://changepw


### PR DESCRIPTION
# 📌관련 이슈

https://github.com/JNU-econovation/EATceed-BE/issues/625

# 🔑 주요 변경사항

회원가입 후 이메일을 보낼 때 URL에 /dev인지 /prod인지 알려주는 prefix가 없어 추가하였습니다.

<img width="858" alt="스크린샷 2025-01-20 오후 6 27 17" src="https://github.com/user-attachments/assets/4dd1e968-14db-4a97-b8b5-da077978838c" />
