### PR TITLE
[BE/FEAT] Async 스레드 풀 사이즈 조절 및 예외 핸들링외 핸들링 및 ThreadPoolTaskExecutor 값 수정

### DIFF
--- a/src/main/java/com/gaebaljip/exceed/adapter/out/aws/EmailAdapter.java
+++ b/src/main/java/com/gaebaljip/exceed/adapter/out/aws/EmailAdapter.java
@@ -8,7 +8,7 @@ import org.thymeleaf.spring5.SpringTemplateEngine;
 import com.gaebaljip.exceed.application.port.out.member.EmailPort;
 
 import lombok.RequiredArgsConstructor;
-import software.amazon.awssdk.services.ses.SesAsyncClient;
+import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.ses.model.*;
 
 @Component
@@ -18,12 +18,11 @@ public class EmailAdapter implements EmailPort {
     @Value("${cloud.aws.ses.mail-address}")
     private String mailAddress;
 
-    private final SesAsyncClient sesAsyncClient;
+    private final SesClient sesClient;
     private final SpringTemplateEngine htmlTemplateEngine;
 
     @Override
     public void sendEmail(String to, String title, String template, Context context) {
-
         String html = htmlTemplateEngine.process(template, context);
 
         SendEmailRequest sendEmailRequest =
@@ -33,7 +32,7 @@ public class EmailAdapter implements EmailPort {
                         .source(mailAddress)
                         .build();
 
-        sesAsyncClient.sendEmail(sendEmailRequest);
+        sesClient.sendEmail(sendEmailRequest);
     }
 
     private Message newMessage(String subject, String html) {

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/InCompleteSignUpMemberEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/InCompleteSignUpMemberEventListener.java
@@ -28,8 +28,8 @@ public class InCompleteSignUpMemberEventListener {
 
     private Long expiredTime = 600000L;
 
-    @EventListener(classes = IncompleteSignUpEvent.class)
     @Async
+    @EventListener(classes = IncompleteSignUpEvent.class)
     public void handle(IncompleteSignUpEvent event) {
         int randomCode = createRandom();
         codePort.saveWithExpiration(event.getEmail(), String.valueOf(randomCode), expiredTime);
@@ -37,16 +37,11 @@ public class InCompleteSignUpMemberEventListener {
         context.setVariable(
                 MailTemplate.SIGN_UP_MAIL_CONTEXT, URL + MailTemplate.REPLY_TO_SIGN_UP_MAIL_URL);
         context.setVariable(MailTemplate.SIGN_UP_CODE, randomCode);
-        try {
-            emailPort.sendEmail(
-                    event.getEmail(),
-                    MailTemplate.SIGN_UP_TITLE,
-                    MailTemplate.SIGN_UP_TEMPLATE,
-                    context);
-        } catch (Exception e) {
-            log.info("msg : {}", "메일 전송에 실패했습니다.");
-            codePort.delete(event.getEmail());
-        }
+        emailPort.sendEmail(
+                event.getEmail(),
+                MailTemplate.SIGN_UP_TITLE,
+                MailTemplate.SIGN_UP_TEMPLATE,
+                context);
     }
 
     private int createRandom() {

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/SendEmailEventListener.java
@@ -1,11 +1,9 @@
 package com.gaebaljip.exceed.common.event.handler;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.thymeleaf.context.Context;
 
 import com.gaebaljip.exceed.application.domain.member.Code;
@@ -27,9 +25,8 @@ public class SendEmailEventListener {
 
     private Long expiredTime = 600000L;
 
-    @TransactionalEventListener(classes = SendEmailEvent.class)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
+    @EventListener(classes = SendEmailEvent.class)
     public void handle(SendEmailEvent event) {
         int randomCode = createRandom();
         codePort.saveWithExpiration(event.getEmail(), String.valueOf(randomCode), expiredTime);

--- a/src/main/java/com/gaebaljip/exceed/common/event/handler/SignUpMemberEventListener.java
+++ b/src/main/java/com/gaebaljip/exceed/common/event/handler/SignUpMemberEventListener.java
@@ -1,11 +1,9 @@
 package com.gaebaljip.exceed.common.event.handler;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.thymeleaf.context.Context;
 
 import com.gaebaljip.exceed.application.domain.member.Code;
@@ -28,9 +26,8 @@ public class SignUpMemberEventListener {
 
     private Long expiredTime = 600000L;
 
-    @TransactionalEventListener(classes = SignUpMemberEvent.class)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Async
+    @EventListener(classes = SignUpMemberEvent.class)
     public void handle(SignUpMemberEvent event) {
         int randomCode = createRandom();
         codePort.saveWithExpiration(event.getEmail(), String.valueOf(randomCode), expiredTime);

--- a/src/main/java/com/gaebaljip/exceed/common/exception/EatCeedAsyncUncaughtExceptionHandler.java
+++ b/src/main/java/com/gaebaljip/exceed/common/exception/EatCeedAsyncUncaughtExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.gaebaljip.exceed.common.exception;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EatCeedAsyncUncaughtExceptionHandler implements AsyncUncaughtExceptionHandler {
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error(
+                "Exception in async method: {}, Params: {}, Message : {}",
+                method.getName(),
+                Arrays.toString(params),
+                ex.getMessage());
+    }
+}

--- a/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
+++ b/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
@@ -1,14 +1,16 @@
 package com.gaebaljip.exceed.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import com.gaebaljip.exceed.common.exception.member.MailSendException;
+import com.gaebaljip.exceed.common.exception.EatCeedAsyncUncaughtExceptionHandler;
 
 @EnableAsync
 @Configuration
@@ -24,5 +26,10 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new EatCeedAsyncUncaughtExceptionHandler();
     }
 }

--- a/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
+++ b/src/main/java/com/gaebaljip/exceed/config/AsyncConfig.java
@@ -17,14 +17,11 @@ public class AsyncConfig implements AsyncConfigurer {
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(16);
-        executor.setMaxPoolSize(25);
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(15);
         executor.setQueueCapacity(10);
-        executor.setKeepAliveSeconds(60);
-        executor.setRejectedExecutionHandler(
-                (r, exec) -> {
-                    throw MailSendException.EXECPTION;
-                });
+        executor.setRejectedExecutionHandler(new AbortPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/gaebaljip/exceed/config/SesConfig.java
+++ b/src/main/java/com/gaebaljip/exceed/config/SesConfig.java
@@ -3,12 +3,14 @@ package com.gaebaljip.exceed.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.ses.SesAsyncClient;
+import software.amazon.awssdk.services.ses.SesClient;
 
 @Configuration
+@Profile("!test")
 public class SesConfig {
 
     @Value("${cloud.aws.credentials.access-key}")
@@ -21,9 +23,8 @@ public class SesConfig {
     private String region;
 
     @Bean
-    public SesAsyncClient sesAsyncClient() {
-
-        return SesAsyncClient.builder()
+    public SesClient sesClient() {
+        return SesClient.builder()
                 .credentialsProvider(() -> AwsBasicCredentials.create(accessKey, secretKey))
                 .region(Region.of(region))
                 .build();

--- a/src/test/java/com/gaebaljip/exceed/common/MockSesConfig.java
+++ b/src/test/java/com/gaebaljip/exceed/common/MockSesConfig.java
@@ -1,0 +1,15 @@
+package com.gaebaljip.exceed.common;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.services.ses.SesClient;
+
+@Configuration
+public class MockSesConfig {
+    @Bean
+    public SesClient sesClient() {
+        return Mockito.mock(SesClient.class);
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈

closes #637 

## 🔑 주요 변경사항

ThreadPoolTaskExecutor 설정 값 수정을 수정하였습니다.

스레드 풀 크기 조정

- corePoolSize: 16 → 5
- maxPoolSize: 25 → 15

작업 처리 정책 변경

- 작업 큐가 가득 차고, maxPoolSize에 도달할 경우 누락 없이 처리하도록 CallerRunsPolicy 적용
- 애플리케이션 종료 시 남은 작업까지 모두 처리되도록 설정

비동기 예외 처리 추가

- EatCeedAsyncUncaughtExceptionHandler 클래스 생성 → 비동기 작업에서 발생하는 예외 처리 담당

테스트 수행

- EATceed 서비스의 현재 사용자는 30명입니다. 동시 요청 개수를 결정하는 과정에서 기준을 정하기 애매했으나, 일단 최대 30개의 동시 요청을 커버하는 것이 적절하다고 판단했습니다.

 
<img width="400" height="300" alt="스크린샷 2025-03-06 오후 6 31 22" src="https://github.com/user-attachments/assets/6f67b098-e31f-426d-b658-76bdecc8cbb0" />

아래와 같이 정상 작동되는 것을 확인하였습니다.

<img width="800" alt="스크린샷 2025-03-06 오후 6 31 34" src="https://github.com/user-attachments/assets/ed005b98-e26e-4cbc-8c37-cb9f7155f05b" />

